### PR TITLE
Allow provided dependencies

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/ScriptDependenciesScannerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/ScriptDependenciesScannerProcessor.java
@@ -2,16 +2,20 @@ package io.quarkiverse.web.bundler.deployment;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.web.bundler.deployment.items.WebDependenciesBuildItem;
 import io.quarkus.deployment.annotations.BuildStep;
-import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.maven.dependency.Dependency;
+import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.paths.PathCollection;
 
@@ -20,17 +24,30 @@ class ScriptDependenciesScannerProcessor {
     private static final Logger LOGGER = Logger.getLogger(ScriptDependenciesScannerProcessor.class);
 
     @BuildStep
-    WebDependenciesBuildItem collectDependencies(ApplicationArchivesBuildItem applicationArchives,
-            CurateOutcomeBuildItem curateOutcome,
+    WebDependenciesBuildItem collectDependencies(CurateOutcomeBuildItem curateOutcome,
             WebBundlerConfig config)
             throws IOException {
-        List<Path> webDeps = curateOutcome.getApplicationModel().getRuntimeDependencies().stream()
-                .filter(Dependency::isJar)
+
+        Set<Path> webDeps = new HashSet<>();
+
+        Iterable<ResolvedDependency> runDependencies = curateOutcome.getApplicationModel()
+                .getDependencies(DependencyFlags.RUNTIME_CP);
+        webDeps.addAll(getWebDependencies(runDependencies, config));
+
+        Iterable<ResolvedDependency> compileDependencies = curateOutcome.getApplicationModel()
+                .getDependencies(DependencyFlags.COMPILE_ONLY);
+        webDeps.addAll(getWebDependencies(compileDependencies, config));
+
+        return new WebDependenciesBuildItem(config.dependencies().type(), List.copyOf(webDeps));
+    }
+
+    private Set<Path> getWebDependencies(Iterable<ResolvedDependency> dependencies, WebBundlerConfig config) {
+        Stream<ResolvedDependency> dependenciesStream = StreamSupport.stream(dependencies.spliterator(), false);
+        return dependenciesStream.filter(Dependency::isJar)
                 .filter(config.dependencies().type()::matches)
                 .map(ResolvedDependency::getResolvedPaths)
                 .flatMap(PathCollection::stream)
                 .filter(p -> p.getFileName().toString().endsWith(".jar"))
-                .collect(Collectors.toList());
-        return new WebDependenciesBuildItem(config.dependencies().type(), webDeps);
+                .collect(Collectors.toSet());
     }
 }

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,4 +1,4 @@
-:project-version: 1.1.2
+:project-version: 1.1.3
 
 :maven-version: 3.8.1+
 

--- a/docs/modules/ROOT/pages/includes/quarkus-web-bundler.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-web-bundler.adoc
@@ -12,6 +12,7 @@ h|Default
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.web-root]]`link:#quarkus-web-bundler_quarkus.web-bundler.web-root[quarkus.web-bundler.web-root]`
 
+
 [.description]
 --
 The directory in the resources which serves as root for the web assets
@@ -22,11 +23,13 @@ endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_WEB_BUNDLER_WEB_ROOT+++`
 endif::add-copy-button-to-env-var[]
---|String 
+--|link:https://docs.oracle.com/javase/8/docs/api/java/lang/String.html[String]
+ 
 |`web`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.static]]`link:#quarkus-web-bundler_quarkus.web-bundler.static[quarkus.web-bundler.static]`
+
 
 [.description]
 --
@@ -38,11 +41,13 @@ endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_WEB_BUNDLER_STATIC+++`
 endif::add-copy-button-to-env-var[]
---|String 
+--|link:https://docs.oracle.com/javase/8/docs/api/java/lang/String.html[String]
+ 
 |`static`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.bundle]]`link:#quarkus-web-bundler_quarkus.web-bundler.bundle[quarkus.web-bundler.bundle]`
+
 
 [.description]
 --
@@ -54,11 +59,13 @@ endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLE+++`
 endif::add-copy-button-to-env-var[]
---|String 
+--|link:https://docs.oracle.com/javase/8/docs/api/java/lang/String.html[String]
+ 
 |`static/bundle`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.presets.app]]`link:#quarkus-web-bundler_quarkus.web-bundler.presets.app[quarkus.web-bundler.presets.app]`
+
 
 [.description]
 --
@@ -76,6 +83,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.presets.app.entry-point-key]]`link:#quarkus-web-bundler_quarkus.web-bundler.presets.app.entry-point-key[quarkus.web-bundler.presets.app.entry-point-key]`
 
+
 [.description]
 --
 The entry point key used for this preset (used in the output)
@@ -91,6 +99,7 @@ endif::add-copy-button-to-env-var[]
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.presets.components]]`link:#quarkus-web-bundler_quarkus.web-bundler.presets.components[quarkus.web-bundler.presets.components]`
+
 
 [.description]
 --
@@ -108,6 +117,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.presets.components.entry-point-key]]`link:#quarkus-web-bundler_quarkus.web-bundler.presets.components.entry-point-key[quarkus.web-bundler.presets.components.entry-point-key]`
 
+
 [.description]
 --
 The entry point key used for this preset (used in the output)
@@ -123,6 +133,7 @@ endif::add-copy-button-to-env-var[]
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.js]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.js[quarkus.web-bundler.loaders.js]`
+
 
 [.description]
 --
@@ -140,6 +151,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.jsx]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.jsx[quarkus.web-bundler.loaders.jsx]`
 
+
 [.description]
 --
 Configure the file extensions using the jsx loader: https://esbuild.github.io/content-types/++#++jsx
@@ -155,6 +167,7 @@ endif::add-copy-button-to-env-var[]
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.tsx]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.tsx[quarkus.web-bundler.loaders.tsx]`
+
 
 [.description]
 --
@@ -172,6 +185,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.ts]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.ts[quarkus.web-bundler.loaders.ts]`
 
+
 [.description]
 --
 Configure the file extensions using the ts loader: https://esbuild.github.io/content-types/++#++typescript
@@ -187,6 +201,7 @@ endif::add-copy-button-to-env-var[]
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.css]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.css[quarkus.web-bundler.loaders.css]`
+
 
 [.description]
 --
@@ -204,6 +219,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.local-css]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.local-css[quarkus.web-bundler.loaders.local-css]`
 
+
 [.description]
 --
 Configure the file extensions using the local-css loader: https://esbuild.github.io/content-types/++#++css
@@ -219,6 +235,7 @@ endif::add-copy-button-to-env-var[]
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.global-css]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.global-css[quarkus.web-bundler.loaders.global-css]`
+
 
 [.description]
 --
@@ -236,6 +253,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.file]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.file[quarkus.web-bundler.loaders.file]`
 
+
 [.description]
 --
 Configure the file extensions using the file loader: https://esbuild.github.io/content-types/++#++file This loader will copy the file to the output directory and embed the file name into the bundle as a string.
@@ -251,6 +269,7 @@ endif::add-copy-button-to-env-var[]
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.copy]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.copy[quarkus.web-bundler.loaders.copy]`
+
 
 [.description]
 --
@@ -268,6 +287,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.base64]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.base64[quarkus.web-bundler.loaders.base64]`
 
+
 [.description]
 --
 Configure the file extensions using the base64 loader: https://esbuild.github.io/content-types/++#++base64
@@ -283,6 +303,7 @@ endif::add-copy-button-to-env-var[]
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.binary]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.binary[quarkus.web-bundler.loaders.binary]`
+
 
 [.description]
 --
@@ -300,6 +321,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.data-url]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.data-url[quarkus.web-bundler.loaders.data-url]`
 
+
 [.description]
 --
 Configure the file extensions using the dataurl loader: https://esbuild.github.io/content-types/++#++data-url
@@ -315,6 +337,7 @@ endif::add-copy-button-to-env-var[]
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.empty]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.empty[quarkus.web-bundler.loaders.empty]`
+
 
 [.description]
 --
@@ -332,6 +355,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.text]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.text[quarkus.web-bundler.loaders.text]`
 
+
 [.description]
 --
 Configure the file extensions using the text loader: https://esbuild.github.io/content-types/++#++text
@@ -348,6 +372,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.loaders.json]]`link:#quarkus-web-bundler_quarkus.web-bundler.loaders.json[quarkus.web-bundler.loaders.json]`
 
+
 [.description]
 --
 Configure the file extensions using the json loader: https://esbuild.github.io/content-types/++#++json
@@ -363,6 +388,7 @@ endif::add-copy-button-to-env-var[]
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.dependencies.type]]`link:#quarkus-web-bundler_quarkus.web-bundler.dependencies.type[quarkus.web-bundler.dependencies.type]`
+
 
 [.description]
 --
@@ -381,6 +407,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.charset]]`link:#quarkus-web-bundler_quarkus.web-bundler.charset[quarkus.web-bundler.charset]`
 
+
 [.description]
 --
 The default charset
@@ -398,6 +425,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.bundle.-bundle]]`link:#quarkus-web-bundler_quarkus.web-bundler.bundle.-bundle[quarkus.web-bundler.bundle."bundle"]`
 
+
 [.description]
 --
 Enable or disable this entry point. You can use this to use the map key as key and dir for this entry point.
@@ -414,6 +442,7 @@ endif::add-copy-button-to-env-var[]
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.bundle.-bundle-.dir]]`link:#quarkus-web-bundler_quarkus.web-bundler.bundle.-bundle-.dir[quarkus.web-bundler.bundle."bundle".dir]`
 
+
 [.description]
 --
 The directory for this entry point under the web root. By default, it will use the bundle map key.
@@ -429,6 +458,7 @@ endif::add-copy-button-to-env-var[]
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus.web-bundler.bundle.-bundle-.key]]`link:#quarkus-web-bundler_quarkus.web-bundler.bundle.-bundle-.key[quarkus.web-bundler.bundle."bundle".key]`
+
 
 [.description]
 --

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.1.3.Final</quarkus.version>
+    <quarkus.version>999-SNAPSHOT</quarkus.version>
 
     <esbuild-java.version>1.0.4</esbuild-java.version>
     <scrimage-core.version>4.0.39</scrimage-core.version>


### PR DESCRIPTION
This PR (still draft) use the new feature from Quarkus to allow provided scoped dependencies

Using mvnpm app as an example, this reduce the size of the final application by 17%. This number will increase the more UI libs you use, so all and all a good saving.

Fixes #84 