### PR TITLE
[Breaking] Introduce source-map config

### DIFF
--- a/common-deployment/src/main/java/io/quarkiverse/web/bundler/deployment/WebBundlerConfig.java
+++ b/common-deployment/src/main/java/io/quarkiverse/web/bundler/deployment/WebBundlerConfig.java
@@ -59,23 +59,9 @@ public interface WebBundlerConfig {
     String bundlePath();
 
     /**
-     * The config for esbuild loaders https://esbuild.github.io/content-types/
+     * Configure bundling options
      */
-    LoadersConfig loaders();
-
-    /**
-     * This defines the list of external paths for esbuild (https://esbuild.github.io/api/#external).
-     * Instead of being bundled, the import will be preserved.
-     */
-    @ConfigDocDefault("{quarkus.http.root-path}static/*")
-    Optional<List<String>> externalImports();
-
-    /**
-     * Enable or disable bundle splitting (https://esbuild.github.io/api/#splitting)
-     * Code shared between multiple entry points is split off into a separate shared file (chunk) that both entry points import
-     */
-    @WithDefault("true")
-    Boolean bundleSplitting();
+    BundlingConfig bundling();
 
     /**
      * Configure how dependencies are collected
@@ -113,6 +99,41 @@ public interface WebBundlerConfig {
 
     default boolean shouldQuarkusServeBundle() {
         return !isExternalBundlePath();
+    }
+
+    interface BundlingConfig {
+        /**
+         * Enable or disable bundle splitting (https://esbuild.github.io/api/#splitting)
+         * Code shared between multiple entry points is split off into a separate shared file (chunk) that both entry points
+         * import
+         */
+        @WithDefault("true")
+        Boolean splitting();
+
+        /**
+         * The config for esbuild loaders https://esbuild.github.io/content-types/
+         */
+        LoadersConfig loaders();
+
+        /**
+         * This defines the list of external paths for esbuild (https://esbuild.github.io/api/#external).
+         * Instead of being bundled, the import will be preserved.
+         */
+        @ConfigDocDefault("{quarkus.http.root-path}static/*")
+        Optional<List<String>> external();
+
+        /**
+         * Configuration for source-map generation (https://esbuild.github.io/api/#sourcemap)
+         */
+        @WithDefault("linked")
+        String sourceMap();
+
+        default boolean sourceMapEnabled() {
+            return "linked".equalsIgnoreCase(sourceMap())
+                    || "true".equalsIgnoreCase(sourceMap())
+                    || "yes".equalsIgnoreCase(sourceMap());
+        }
+
     }
 
     interface WebDependenciesConfig {

--- a/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/WebBundlerProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/WebBundlerProcessor.java
@@ -159,15 +159,16 @@ class WebBundlerProcessor {
             final EsBuildConfigBuilder esBuildConfigBuilder = new EsBuildConfigBuilder()
                     .loader(loaders)
                     .publicPath(config.publicBundlePath())
-                    .splitting(config.bundleSplitting())
+                    .splitting(config.bundling().splitting())
                     .minify(launchMode.getLaunchMode().equals(LaunchMode.NORMAL));
-            if (config.externalImports().isPresent()) {
-                for (String e : config.externalImports().get()) {
+            if (config.bundling().external().isPresent()) {
+                for (String e : config.bundling().external().get()) {
                     esBuildConfigBuilder.addExternal(e);
                 }
             } else {
                 esBuildConfigBuilder.addExternal(join(config.httpRootPath(), "static/*"));
             }
+            esBuildConfigBuilder.sourceMap(config.bundling().sourceMapEnabled());
             final BundleOptionsBuilder optionsBuilder = new BundleOptionsBuilder()
                     .withWorkDir(targetDir)
                     .withDependencies(webDependencies.list().stream().map(Dependency::toEsBuildWebDependency).toList())
@@ -283,7 +284,7 @@ class WebBundlerProcessor {
         Map<String, EsBuildConfig.Loader> loaders = new HashMap<>();
         for (EsBuildConfig.Loader loader : EsBuildConfig.Loader.values()) {
             final Function<LoadersConfig, Optional<Set<String>>> configFn = requireNonNull(LOADER_CONFIGS.get(loader));
-            final Optional<Set<String>> values = configFn.apply(config.loaders());
+            final Optional<Set<String>> values = configFn.apply(config.bundling().loaders());
             if (values.isPresent()) {
                 for (String v : values.get()) {
                     final String ext = v.startsWith(".") ? v : "." + v;

--- a/deployment/src/test/java/io/quarkiverse/web/bundler/test/WebBundlerAutoImportTest.java
+++ b/deployment/src/test/java/io/quarkiverse/web/bundler/test/WebBundlerAutoImportTest.java
@@ -19,12 +19,12 @@ public class WebBundlerAutoImportTest {
 
     @RegisterExtension
     static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withConfigurationResource("application-auto.properties")
             .setForcedDependencies(
                     List.of(
                             new ArtifactDependency("org.mvnpm", "jquery", null, "jar", "3.7.0", "provided", false)))
             .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
-                    .addAsResource("web-auto", "web")
-                    .addAsResource("application-auto.properties", "application.properties"));
+                    .addAsResource("web-auto", "web"));
 
     @Inject
     Bundle bundle;

--- a/deployment/src/test/java/io/quarkiverse/web/bundler/test/WebBundlerSourceMapDisabledTest.java
+++ b/deployment/src/test/java/io/quarkiverse/web/bundler/test/WebBundlerSourceMapDisabledTest.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.web.bundler.test;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.web.bundler.runtime.Bundle;
+import io.quarkus.maven.dependency.ArtifactDependency;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class WebBundlerSourceMapDisabledTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withConfigurationResource("application.properties")
+            .overrideConfigKey("quarkus.web-bundler.bundling.source-map", "false")
+            .setForcedDependencies(
+                    List.of(new ArtifactDependency("org.mvnpm", "jquery", null, "jar", "3.7.0", "provided", false)))
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("web"));
+
+    @Inject
+    Bundle bundle;
+
+    @Test
+    public void test() {
+        Assertions.assertNull(bundle.resolve("main.js.map"));
+        Assertions.assertNull(bundle.resolve("main.css.map"));
+    }
+}

--- a/docs/modules/ROOT/pages/advanced-guides.adoc
+++ b/docs/modules/ROOT/pages/advanced-guides.adoc
@@ -106,9 +106,9 @@ NOTE: By default, as soon as more than one entry-point key is configured, shared
 [#loaders]
 === How is it bundled (Loaders)
 
-Bases on the files extensions, the Web Bundler will use xref:config-reference.adoc#quarkus-web-bundler_quarkus.web-bundler.loaders.js[pre-configured loaders] to bundle them. For scripts and styles, the default configuration should be enough.
+Bases on the files extensions, the Web Bundler will use xref:config-reference.adoc#quarkus-web-bundler_quarkus.web-bundler.bundling.loaders.js[pre-configured loaders] to bundle them. For scripts and styles, the default configuration should be enough.
 
-For other assets (svg, gif, png, jpg, ttf, ...) imported from your scripts and styles using their relative path, you may choose the loader based on the file extension allowing different options (e.g. serving, embedding the file as data-url, binary, base64, ...). By default, they will automatically be copied and served using the xref:config-reference.adoc#quarkus-web-bundler_quarkus.web-bundler.loaders.file[file loader].
+For other assets (svg, gif, png, jpg, ttf, ...) imported from your scripts and styles using their relative path, you may choose the loader based on the file extension allowing different options (e.g. serving, embedding the file as data-url, binary, base64, ...). By default, they will automatically be copied and served using the xref:config-reference.adoc#quarkus-web-bundler_quarkus.web-bundler.bundling.loaders.file[file loader].
 
 For example, `url('./example.png')` in a style or `import example from './example.png';` in a script will be processed, the file will be copied with a static name and the path will be replaced by the new file static path (e.g. `/static/bundle/assets/example-QH383.png`). The `example` variable will contain the public path to this file to be used in a component img `src` for example.
 

--- a/docs/modules/ROOT/pages/includes/quarkus-web-bundler.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-web-bundler.adoc
@@ -61,279 +61,7 @@ endif::add-copy-button-to-env-var[]
 |`static/bundle`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-js]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-js[quarkus.web-bundler.loaders.js]`
-
-
-[.description]
---
-Configure the file extensions using the js loader: https://esbuild.github.io/content-types/++#++javascript
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_JS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_JS+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|`js,cjs,mjs`
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-jsx]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-jsx[quarkus.web-bundler.loaders.jsx]`
-
-
-[.description]
---
-Configure the file extensions using the jsx loader: https://esbuild.github.io/content-types/++#++jsx
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_JSX+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_JSX+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|`jsx`
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-tsx]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-tsx[quarkus.web-bundler.loaders.tsx]`
-
-
-[.description]
---
-Configure the file extensions using the tsx loader: https://esbuild.github.io/content-types/++#++jsx
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_TSX+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_TSX+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|`tsx`
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-ts]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-ts[quarkus.web-bundler.loaders.ts]`
-
-
-[.description]
---
-Configure the file extensions using the ts loader: https://esbuild.github.io/content-types/++#++typescript
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_TS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_TS+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|`ts,mts,cts`
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-css]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-css[quarkus.web-bundler.loaders.css]`
-
-
-[.description]
---
-Configure the file extensions using the css loader: https://esbuild.github.io/content-types/++#++css
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_CSS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_CSS+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|`css`
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-local-css]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-local-css[quarkus.web-bundler.loaders.local-css]`
-
-
-[.description]
---
-Configure the file extensions using the local-css loader: https://esbuild.github.io/content-types/++#++css
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_LOCAL_CSS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_LOCAL_CSS+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|`.module.css`
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-global-css]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-global-css[quarkus.web-bundler.loaders.global-css]`
-
-
-[.description]
---
-Configure the file extensions using the global-css loader: https://esbuild.github.io/content-types/++#++css
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_GLOBAL_CSS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_GLOBAL_CSS+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-file]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-file[quarkus.web-bundler.loaders.file]`
-
-
-[.description]
---
-Configure the file extensions using the file loader: https://esbuild.github.io/content-types/++#++file This loader will copy the file to the output directory and embed the file name into the bundle as a string.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_FILE+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_FILE+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|`aac,abw,arc,avif,avi,azw,bin,bmp,bz,bz2,cda,csv,yaml,yml,doc,docx,eot,epub,gz,gif,htm,html,ico,ics,jar,jpeg,jpg,jsonld,mid,midi,mp3,mp4,mpeg,mpkg,odp,ods,odt,oga,ogv,ogx,opus,otf,png,pdf,ppt,pptx,rar,rtf,svg,tar,tif,tiff,ttf,vsd,wav,weba,webm,webp,woff,woff2,xhtml,xls,xlsx,xml,xul,zip,3gp,3g2,7z`
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-copy]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-copy[quarkus.web-bundler.loaders.copy]`
-
-
-[.description]
---
-Configure the file extensions using the copy loader: https://esbuild.github.io/content-types/++#++copy
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_COPY+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_COPY+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-base64]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-base64[quarkus.web-bundler.loaders.base64]`
-
-
-[.description]
---
-Configure the file extensions using the base64 loader: https://esbuild.github.io/content-types/++#++base64
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_BASE64+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_BASE64+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-binary]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-binary[quarkus.web-bundler.loaders.binary]`
-
-
-[.description]
---
-Configure the file extensions using the binary loader: https://esbuild.github.io/content-types/++#++binary
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_BINARY+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_BINARY+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-data-url]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-data-url[quarkus.web-bundler.loaders.data-url]`
-
-
-[.description]
---
-Configure the file extensions using the dataurl loader: https://esbuild.github.io/content-types/++#++data-url
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_DATA_URL+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_DATA_URL+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-empty]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-empty[quarkus.web-bundler.loaders.empty]`
-
-
-[.description]
---
-Configure the file extensions using the empty loader: https://esbuild.github.io/content-types/++#++empty-file
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_EMPTY+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_EMPTY+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-text]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-text[quarkus.web-bundler.loaders.text]`
-
-
-[.description]
---
-Configure the file extensions using the text loader: https://esbuild.github.io/content-types/++#++text
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_TEXT+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_TEXT+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|`txt`
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-loaders-json]]`link:#quarkus-web-bundler_quarkus-web-bundler-loaders-json[quarkus.web-bundler.loaders.json]`
-
-
-[.description]
---
-Configure the file extensions using the json loader: https://esbuild.github.io/content-types/++#++json
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_LOADERS_JSON+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_LOADERS_JSON+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|`json`
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-external-imports]]`link:#quarkus-web-bundler_quarkus-web-bundler-external-imports[quarkus.web-bundler.external-imports]`
-
-
-[.description]
---
-This defines the list of external paths for esbuild (https://esbuild.github.io/api/++#++external). Instead of being bundled, the import will be preserved.
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_EXTERNAL_IMPORTS+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_EXTERNAL_IMPORTS+++`
-endif::add-copy-button-to-env-var[]
---|list of string 
-|`{quarkus.http.root-path}static/*`
-
-
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-splitting]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundle-splitting[quarkus.web-bundler.bundle-splitting]`
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-splitting]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-splitting[quarkus.web-bundler.bundling.splitting]`
 
 
 [.description]
@@ -341,13 +69,302 @@ a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler
 Enable or disable bundle splitting (https://esbuild.github.io/api/++#++splitting) Code shared between multiple entry points is split off into a separate shared file (chunk) that both entry points import
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLE_SPLITTING+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_SPLITTING+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLE_SPLITTING+++`
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_SPLITTING+++`
 endif::add-copy-button-to-env-var[]
 --|boolean 
 |`true`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-js]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-js[quarkus.web-bundler.bundling.loaders.js]`
+
+
+[.description]
+--
+Configure the file extensions using the js loader: https://esbuild.github.io/content-types/++#++javascript
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_JS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_JS+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|`js,cjs,mjs`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-jsx]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-jsx[quarkus.web-bundler.bundling.loaders.jsx]`
+
+
+[.description]
+--
+Configure the file extensions using the jsx loader: https://esbuild.github.io/content-types/++#++jsx
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_JSX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_JSX+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|`jsx`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-tsx]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-tsx[quarkus.web-bundler.bundling.loaders.tsx]`
+
+
+[.description]
+--
+Configure the file extensions using the tsx loader: https://esbuild.github.io/content-types/++#++jsx
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_TSX+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_TSX+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|`tsx`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-ts]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-ts[quarkus.web-bundler.bundling.loaders.ts]`
+
+
+[.description]
+--
+Configure the file extensions using the ts loader: https://esbuild.github.io/content-types/++#++typescript
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_TS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_TS+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|`ts,mts,cts`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-css]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-css[quarkus.web-bundler.bundling.loaders.css]`
+
+
+[.description]
+--
+Configure the file extensions using the css loader: https://esbuild.github.io/content-types/++#++css
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_CSS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_CSS+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|`css`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-local-css]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-local-css[quarkus.web-bundler.bundling.loaders.local-css]`
+
+
+[.description]
+--
+Configure the file extensions using the local-css loader: https://esbuild.github.io/content-types/++#++css
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_LOCAL_CSS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_LOCAL_CSS+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|`.module.css`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-global-css]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-global-css[quarkus.web-bundler.bundling.loaders.global-css]`
+
+
+[.description]
+--
+Configure the file extensions using the global-css loader: https://esbuild.github.io/content-types/++#++css
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_GLOBAL_CSS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_GLOBAL_CSS+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-file]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-file[quarkus.web-bundler.bundling.loaders.file]`
+
+
+[.description]
+--
+Configure the file extensions using the file loader: https://esbuild.github.io/content-types/++#++file This loader will copy the file to the output directory and embed the file name into the bundle as a string.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_FILE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_FILE+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|`aac,abw,arc,avif,avi,azw,bin,bmp,bz,bz2,cda,csv,yaml,yml,doc,docx,eot,epub,gz,gif,htm,html,ico,ics,jar,jpeg,jpg,jsonld,mid,midi,mp3,mp4,mpeg,mpkg,odp,ods,odt,oga,ogv,ogx,opus,otf,png,pdf,ppt,pptx,rar,rtf,svg,tar,tif,tiff,ttf,vsd,wav,weba,webm,webp,woff,woff2,xhtml,xls,xlsx,xml,xul,zip,3gp,3g2,7z`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-copy]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-copy[quarkus.web-bundler.bundling.loaders.copy]`
+
+
+[.description]
+--
+Configure the file extensions using the copy loader: https://esbuild.github.io/content-types/++#++copy
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_COPY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_COPY+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-base64]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-base64[quarkus.web-bundler.bundling.loaders.base64]`
+
+
+[.description]
+--
+Configure the file extensions using the base64 loader: https://esbuild.github.io/content-types/++#++base64
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_BASE64+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_BASE64+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-binary]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-binary[quarkus.web-bundler.bundling.loaders.binary]`
+
+
+[.description]
+--
+Configure the file extensions using the binary loader: https://esbuild.github.io/content-types/++#++binary
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_BINARY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_BINARY+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-data-url]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-data-url[quarkus.web-bundler.bundling.loaders.data-url]`
+
+
+[.description]
+--
+Configure the file extensions using the dataurl loader: https://esbuild.github.io/content-types/++#++data-url
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_DATA_URL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_DATA_URL+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-empty]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-empty[quarkus.web-bundler.bundling.loaders.empty]`
+
+
+[.description]
+--
+Configure the file extensions using the empty loader: https://esbuild.github.io/content-types/++#++empty-file
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_EMPTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_EMPTY+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-text]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-text[quarkus.web-bundler.bundling.loaders.text]`
+
+
+[.description]
+--
+Configure the file extensions using the text loader: https://esbuild.github.io/content-types/++#++text
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_TEXT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_TEXT+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|`txt`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-json]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-json[quarkus.web-bundler.bundling.loaders.json]`
+
+
+[.description]
+--
+Configure the file extensions using the json loader: https://esbuild.github.io/content-types/++#++json
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_JSON+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_LOADERS_JSON+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|`json`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-external]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-external[quarkus.web-bundler.bundling.external]`
+
+
+[.description]
+--
+This defines the list of external paths for esbuild (https://esbuild.github.io/api/++#++external). Instead of being bundled, the import will be preserved.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_EXTERNAL+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_EXTERNAL+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|`{quarkus.http.root-path}static/*`
+
+
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-source-map]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-source-map[quarkus.web-bundler.bundling.source-map]`
+
+
+[.description]
+--
+Configuration for source-map generation (https://esbuild.github.io/api/++#++sourcemap)
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_SOURCE_MAP+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_SOURCE_MAP+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|`linked`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-dependencies-node-modules]]`link:#quarkus-web-bundler_quarkus-web-bundler-dependencies-node-modules[quarkus.web-bundler.dependencies.node-modules]`


### PR DESCRIPTION
Closes #194 

This is breaking (cleaning) some existing configurations, all bundling options are now moved to `quarkus.web-bundler.bundling`:
- bundling.splitting 
- bundling.loaders
- bundling.external
- bundling.source-map (new)

Source map can be disabled with "false":
```properties
quarkus.web-bundler.bundling.source-map=false
```

New options for source-map will be available when this https://github.com/mvnpm/esbuild-java/issues/108 is ready

