### PR TITLE
Fix continuous testing

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/PrepareForBundlingProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/PrepareForBundlingProcessor.java
@@ -58,7 +58,7 @@ public class PrepareForBundlingProcessor {
                     entry(EsBuildConfig.Loader.DATAURL, LoadersConfig::dataUrl),
                     entry(EsBuildConfig.Loader.BASE64, LoadersConfig::base64),
                     entry(EsBuildConfig.Loader.BINARY, LoadersConfig::binary));
-    public static final String TARGET_DIR_NAME = "web-bundler";
+    public static final String TARGET_DIR_NAME = "web-bundler/";
     public static final String DIST = "dist";
 
     static {
@@ -70,8 +70,9 @@ public class PrepareForBundlingProcessor {
     }
 
     @BuildStep
-    WebBundlerTargetDirBuildItem initTargetDir(OutputTargetBuildItem outputTarget) {
-        final Path targetDir = outputTarget.getOutputDirectory().resolve(TARGET_DIR_NAME);
+    WebBundlerTargetDirBuildItem initTargetDir(OutputTargetBuildItem outputTarget, LaunchModeBuildItem launchMode) {
+        final String targetDirName = TARGET_DIR_NAME + launchMode.getLaunchMode().getDefaultProfile();
+        final Path targetDir = outputTarget.getOutputDirectory().resolve(targetDirName);
         final Path distDir = targetDir.resolve(DIST);
         return new WebBundlerTargetDirBuildItem(targetDir, distDir);
     }

--- a/docs/modules/ROOT/pages/includes/quarkus-web-bundler.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-web-bundler.adoc
@@ -539,7 +539,7 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-envs-envs]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-envs-envs[quarkus.web-bundler.bundling.envs]`
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-envs-envs]]`link:#quarkus-web-bundler_quarkus-web-bundler-bundling-envs-envs[quarkus.web-bundler.bundling.envs."envs"]`
 
 
 [.description]
@@ -547,12 +547,13 @@ a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler
 List of environments for the bundle
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_ENVS+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_WEB_BUNDLER_BUNDLING_ENVS__ENVS_+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_ENVS+++`
+Environment variable: `+++QUARKUS_WEB_BUNDLER_BUNDLING_ENVS__ENVS_+++`
 endif::add-copy-button-to-env-var[]
---|`Map<String,String>` 
+--|link:https://docs.oracle.com/javase/8/docs/api/java/lang/String.html[String]
+ 
 |
 
 |===


### PR DESCRIPTION
@maxandersen @FroMage @xstefank  this should fix continuous testing.

Issue was that running the test in the same directory was messing with the esbuild watch.


**This changes the web-bundler output directory to `target/web-bundler/[dev,prod,test]/`, depending on the launch mode.**