### PR TITLE
Improve the readme generated by the starter code

### DIFF
--- a/runtime/src/main/codestarts/quarkus/web-bundler-codestart/codestart.yml
+++ b/runtime/src/main/codestarts/quarkus/web-bundler-codestart/codestart.yml
@@ -4,6 +4,6 @@ type: code
 tags: extension-codestart
 metadata:
   title: Web Bundler
-  description: This is a tiny app web-bundler.html to get started with the Web Bundler.
+  description: This is a tiny app `web-bundler.html` to get started with the Web Bundler. Once the quarkus app is started visit the generated page at http://localhost:8080/web-bundler.html
   path: /web-bundler.html
   related-guide-section: https://docs.quarkiverse.io/quarkus-web-bundler/dev/


### PR DESCRIPTION
When you are like me and you don't know where to load the `html` page served by quarkus present in the starter code, I think the generated README could mention it.
