### PR TITLE
Make sure web bundler entries are sorted

### DIFF
--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/BundleProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/BundleProcessor.java
@@ -101,7 +101,7 @@ class BundleProcessor {
             List<String> names = new ArrayList<>();
             StringBuilder mappingString = new StringBuilder();
             try (Stream<Path> stream = Files.find(bundleDir, 20, (p, i) -> Files.isRegularFile(p))) {
-                stream.forEach(path -> {
+                stream.sorted().forEach(path -> {
                     final String relativePath = toUnixPath(bundleDir.relativize(path).toString());
                     final String key = fixedNames && !relativePath.contains("chunk") ? relativePath
                             : relativePath.replaceAll("-[^-.]+\\.", ".");

--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/BundleWebAssetsScannerProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/BundleWebAssetsScannerProcessor.java
@@ -82,7 +82,7 @@ class BundleWebAssetsScannerProcessor {
 
         final List<Scanner> bundleConfigAssetsScanners = new ArrayList<>();
 
-        final Map<String, EntryPoint> entryPoints = new HashMap<>();
+        final Map<String, EntryPoint> entryPoints = new TreeMap<>();
 
         // This is legacy support for web/app dir
         boolean appDir = checkAppDir(config);

--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/devui/WebBundlerDevUIProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/devui/WebBundlerDevUIProcessor.java
@@ -56,6 +56,7 @@ public class WebBundlerDevUIProcessor {
         if (!entryPoints.isEmpty()) {
             final List<EntryPoint> entryPointsForDevUI = entryPoints.stream()
                     .map(e -> new EntryPoint(e.key(), getEntryPointItems(generatedEntryPointsMap, e)))
+                    .sorted(Comparator.comparing(EntryPoint::key))
                     .toList();
 
             cardPageBuildItem.addBuildTimeData("entryPoints",

--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/items/WebDependenciesBuildItem.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/items/WebDependenciesBuildItem.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.web.bundler.deployment.items;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 
 import io.mvnpm.esbuild.model.WebDependency;
@@ -16,7 +17,7 @@ public final class WebDependenciesBuildItem extends SimpleBuildItem {
     }
 
     public List<Dependency> list() {
-        return list;
+        return list.stream().sorted(Comparator.comparing(Dependency::path)).toList();
     }
 
     public boolean isEmpty() {


### PR DESCRIPTION
This PR makes sure the entries are properly sorted (by name);

- For the "Web Dependencies" tab in the Dev UI
- For the "Entry Points" tab in the Dev UI
- In the output of the web bundler logs

We have quite a large project, where we recently migrated to the Web Bundler. It's a simple server side rendered web app with Quarkus Qute, and some pages are enhanced with some JavaScript. Each page would also use some shared JS, we now replaced this with small web bundles for each page. We have roughly 35+ specific bundles now and that made them hard to find in the Dev UI. This PR tries to improve that a bit.

This extension is pretty cool! Now we can simplify our setup and users no longer have to do a force refresh in their browser when we deploy (as static assets would be cached 24h).