### PR TITLE
Consume WebDependencyJarBuildItem SPI for extension web assets

### DIFF
--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/WebDependenciesProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/WebDependenciesProcessor.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -62,9 +63,25 @@ class WebDependenciesProcessor {
                 .map(WebDependenciesProcessor::toWebDep)
                 .filter(Objects::nonNull)
                 .toList();
-        final List<Dependency> dependencies = new ArrayList<>(buildDependencies.size() + runtimeDependencies.size());
+        // Discover Quarkus extension JARs that ship META-INF/importmap.json (e.g. extensions with JS assets)
+        final List<Dependency> importMapDependencies = StreamSupport.stream(curateOutcome.getApplicationModel()
+                .getDependencies(DependencyFlags.RUNTIME_EXTENSION_ARTIFACT).spliterator(), false)
+                .filter(io.quarkus.maven.dependency.Dependency::isJar)
+                .filter(d -> !WebDependencyType.anyMatch(d.toCompactCoords()))
+                .filter(WebDependenciesProcessor::hasImportMap)
+                .map(d -> toWebDep(d, WebDependencyType.MVNPM))
+                .filter(Objects::nonNull)
+                .toList();
+        if (!importMapDependencies.isEmpty()) {
+            LOGGER.debugf("Discovered %d web dependencies via META-INF/importmap.json: %s",
+                    importMapDependencies.size(),
+                    importMapDependencies.stream().map(Dependency::id).collect(Collectors.joining(", ")));
+        }
+        final List<Dependency> dependencies = new ArrayList<>(
+                buildDependencies.size() + runtimeDependencies.size() + importMapDependencies.size());
         dependencies.addAll(buildDependencies);
         dependencies.addAll(runtimeDependencies);
+        dependencies.addAll(importMapDependencies);
         return new WebDependenciesBuildItem(dependencies);
     }
 
@@ -124,10 +141,30 @@ class WebDependenciesProcessor {
     }
 
     private static Dependency toWebDep(ResolvedDependency d) {
+        return toWebDep(d, resolveType(d.toCompactCoords()).orElseThrow());
+    }
+
+    private static Dependency toWebDep(ResolvedDependency d, WebDependencyType type) {
         return d.getResolvedPaths().stream().filter(p -> p.getFileName().toString().endsWith(".jar")).findFirst()
-                .map(j -> new Dependency(d, d.toCompactCoords(), j, resolveType(d.toCompactCoords()).orElseThrow(),
-                        d.isDirect()))
+                .map(j -> new Dependency(d, d.toCompactCoords(), j, type, d.isDirect()))
                 .orElse(null);
+    }
+
+    private static boolean hasImportMap(ResolvedDependency d) {
+        return d.getResolvedPaths().stream()
+                .filter(p -> p.getFileName().toString().endsWith(".jar"))
+                .findFirst()
+                .map(WebDependenciesProcessor::jarContainsImportMap)
+                .orElse(false);
+    }
+
+    private static boolean jarContainsImportMap(Path jarPath) {
+        try (JarFile jarFile = new JarFile(jarPath.toFile())) {
+            return jarFile.getEntry("META-INF/importmap.json") != null;
+        } catch (IOException e) {
+            LOGGER.debugf("Could not inspect JAR for importmap.json: %s", jarPath);
+            return false;
+        }
     }
 
     private static Path resolveNodeModulesDir(WebBundlerConfig config, OutputTargetBuildItem outputTarget,

--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/WebDependenciesProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/WebDependenciesProcessor.java
@@ -9,7 +9,9 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -30,9 +32,11 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.vertx.http.deployment.spi.WebDependencyJarBuildItem;
 
 class WebDependenciesProcessor {
 
@@ -42,6 +46,7 @@ class WebDependenciesProcessor {
     WebDependenciesBuildItem collectDependencies(LaunchModeBuildItem launchMode,
             CurateOutcomeBuildItem curateOutcome,
             List<EntryPointBuildItem> entryPoints,
+            List<WebDependencyJarBuildItem> webDependencyJars,
             WebBundlerConfig config) {
         if (entryPoints.isEmpty() && !config.dependencies().autoImport().isEnabled()) {
             return new WebDependenciesBuildItem(List.of());
@@ -62,9 +67,17 @@ class WebDependenciesProcessor {
                 .map(WebDependenciesProcessor::toWebDep)
                 .filter(Objects::nonNull)
                 .toList();
-        final List<Dependency> dependencies = new ArrayList<>(buildDependencies.size() + runtimeDependencies.size());
+        final List<Dependency> extensionDependencies = toExtensionWebDeps(curateOutcome, webDependencyJars);
+        if (!extensionDependencies.isEmpty()) {
+            LOGGER.debugf("Discovered %d extension web dependencies: %s",
+                    extensionDependencies.size(),
+                    extensionDependencies.stream().map(Dependency::id).collect(Collectors.joining(", ")));
+        }
+        final List<Dependency> dependencies = new ArrayList<>(
+                buildDependencies.size() + runtimeDependencies.size() + extensionDependencies.size());
         dependencies.addAll(buildDependencies);
         dependencies.addAll(runtimeDependencies);
+        dependencies.addAll(extensionDependencies);
         return new WebDependenciesBuildItem(dependencies);
     }
 
@@ -128,6 +141,29 @@ class WebDependenciesProcessor {
                 .map(j -> new Dependency(d, d.toCompactCoords(), j, resolveType(d.toCompactCoords()).orElseThrow(),
                         d.isDirect()))
                 .orElse(null);
+    }
+
+    private static List<Dependency> toExtensionWebDeps(CurateOutcomeBuildItem curateOutcome,
+            List<WebDependencyJarBuildItem> webDependencyJars) {
+        if (webDependencyJars.isEmpty()) {
+            return List.of();
+        }
+        final Map<ArtifactKey, ResolvedDependency> depsByKey = curateOutcome.getApplicationModel()
+                .getDependencies().stream()
+                .collect(Collectors.toMap(ResolvedDependency::getKey, Function.identity(), (a, b) -> a));
+        return webDependencyJars.stream()
+                .map(item -> {
+                    ResolvedDependency resolved = depsByKey.get(item.getArtifactKey());
+                    if (resolved == null) {
+                        LOGGER.debugf("WebDependencyJarBuildItem for %s has no matching resolved dependency",
+                                item.getArtifactKey());
+                        return null;
+                    }
+                    return new Dependency(resolved, resolved.toCompactCoords(), item.getJarPath(),
+                            WebDependencyType.MVNPM, resolved.isDirect());
+                })
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     private static Path resolveNodeModulesDir(WebBundlerConfig config, OutputTargetBuildItem outputTarget,

--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/WebDependenciesProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/WebDependenciesProcessor.java
@@ -160,7 +160,7 @@ class WebDependenciesProcessor {
                         return null;
                     }
                     return new Dependency(resolved, resolved.toCompactCoords(), item.getJarPath(),
-                            WebDependencyType.MVNPM, resolved.isDirect());
+                            WebDependencyType.MVNPM, resolved.isDirect(), item.getImportMappings());
                 })
                 .filter(Objects::nonNull)
                 .toList();

--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/items/WebDependenciesBuildItem.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/items/WebDependenciesBuildItem.java
@@ -3,6 +3,7 @@ package io.quarkiverse.web.bundler.deployment.items;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 import io.mvnpm.esbuild.model.WebDependency;
 import io.quarkus.builder.item.SimpleBuildItem;
@@ -29,7 +30,12 @@ public final class WebDependenciesBuildItem extends SimpleBuildItem {
     }
 
     public record Dependency(ResolvedDependency resolvedDependency, String id, Path path, WebDependency.WebDependencyType type,
-            boolean direct) {
+            boolean direct, Map<String, String> importMappings) {
+
+        public Dependency(ResolvedDependency resolvedDependency, String id, Path path, WebDependency.WebDependencyType type,
+                boolean direct) {
+            this(resolvedDependency, id, path, type, direct, null);
+        }
 
         public WebDependency toEsBuildWebDependency() {
             return WebDependency.of(id, path, type);

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <esbuild-java.version>2.1.3</esbuild-java.version>
-        <quarkus.version>3.29.4</quarkus.version>
+        <quarkus.version>3.35.2</quarkus.version>
         <assertj-core.version>3.27.7</assertj-core.version>
         <quarkus-playwright.version>2.3.4</quarkus-playwright.version>
     </properties>


### PR DESCRIPTION
Quarkus extensions that ship JavaScript modules (e.g. quarkus-json-rpc) are invisible to web-bundler because their Maven group ID doesn't match `org.mvnpm` or `org.webjars.npm`.

The initial approach on this branch scanned every runtime extension JAR looking for `META-INF/importmap.json`. Now that quarkusio/quarkus#53555 has landed, this switches to consuming the `WebDependencyJarBuildItem` SPI instead — extensions declare themselves as web dependency providers, and web-bundler just listens. No JAR scanning needed.

Also bumps Quarkus from 3.29.4 to 3.35.2 to pick up the new SPI.

Closes #425