### PR TITLE
Fix DevWatcher deadlock during directory reconciliation

### DIFF
--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/DevWatcherProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/DevWatcherProcessor.java
@@ -125,11 +125,13 @@ public class DevWatcherProcessor {
         }
 
         public void reconcileWatchedDirs(Collection<Path> previousDirs, Collection<Path> watchedDirs) {
-            for (Path previousDir : previousDirs) {
-                watcher.unwatchPath(previousDir, callback);
-            }
+            // Only add new directories. Unwatching during reload can deadlock with the
+            // PollingWatchService timer thread (AB-BA lock ordering in JDK internals).
+            // Stale watches are harmless since handleChanges filters by webDirs/started.
             for (Path watchedDir : watchedDirs) {
-                watcher.watchDirectoryRecursively(watchedDir, callback);
+                if (!previousDirs.contains(watchedDir)) {
+                    watcher.watchDirectoryRecursively(watchedDir, callback);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
Fix a deadlock between `reconcileWatchedDirs()` and the `PollingWatchService` timer thread during hot-reload.

The deadlock occurs because `unwatchPath()` locks the `WatchServiceFileSystemWatcher`, then tries to lock the `PollingWatchKey` via `cancel()`. Meanwhile, the polling thread holds the key lock and needs the watcher's `HashMap` lock. Classic AB-BA lock ordering issue in JDK's `sun.nio.fs.PollingWatchService` internals.

Fix: only add new directories during reconciliation, never unwatch old ones. Stale watches are harmless since `handleChanges` filters events by `webDirs` and the `started` flag.