### PR TITLE
docs: fix missing include files in nav.adoc

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,6 +1,3 @@
-include::./includes/attributes.adoc[]
-:config-file: application.properties
-
 * xref:index.adoc[Getting started]
 * xref:main-concepts.adoc[Main Concepts]
 * xref:advanced-guides.adoc[Advanced Guides]


### PR DESCRIPTION
## Summary
- Remove `include::./includes/attributes.adoc[]` and unused `:config-file:` attribute from `nav.adoc`
- The include target does not exist at `docs/modules/ROOT/includes/` — it only exists under `pages/_includes/`
- Navigation files only contain `xref` entries and don't need these attributes

Fixes Antora build error:
- `target of include not found: ./includes/attributes.adoc`
- `target of include not found: ./_includes/attributes.adoc`

Backport of #440 to the `1.x` branch.