### PR TITLE
Contribute NPM dependencies to Quarkus SBOM

### DIFF
--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/WebDependenciesProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/WebDependenciesProcessor.java
@@ -8,7 +8,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -25,18 +27,27 @@ import io.quarkiverse.web.bundler.deployment.items.EntryPointBuildItem;
 import io.quarkiverse.web.bundler.deployment.items.InstalledWebDependenciesBuildItem;
 import io.quarkiverse.web.bundler.deployment.items.WebDependenciesBuildItem;
 import io.quarkiverse.web.bundler.deployment.items.WebDependenciesBuildItem.Dependency;
+import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.deployment.sbom.SbomContributionBuildItem;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ArtifactKey;
 import io.quarkus.maven.dependency.DependencyFlags;
 import io.quarkus.maven.dependency.ResolvedDependency;
 import io.quarkus.runtime.configuration.ConfigurationException;
+import io.quarkus.sbom.ComponentDependencies;
+import io.quarkus.sbom.ComponentDescriptor;
+import io.quarkus.sbom.Purl;
+import io.quarkus.sbom.SbomContribution;
 
 class WebDependenciesProcessor {
 
     private static final Logger LOGGER = Logger.getLogger(WebDependenciesProcessor.class);
+    private static final String ORG_MVNPM_AT = "org.mvnpm.at.";
 
     @BuildStep
     WebDependenciesBuildItem collectDependencies(LaunchModeBuildItem launchMode,
@@ -121,6 +132,71 @@ class WebDependenciesProcessor {
                             " Use a compile only scope (e.g. provided) or set quarkus.web-bundler.dependencies.compile-only=false to allow runtime web dependencies.")
                             .formatted(d.toCompactCoords()));
         }
+    }
+
+    @BuildStep
+    void produceSbomContribution(
+            InstalledWebDependenciesBuildItem installed,
+            BuildProducer<SbomContributionBuildItem> sbomProducer) {
+        if (installed == null || installed.isEmpty()) {
+            return;
+        }
+        final SbomContribution contribution = toSbomContribution(installed.list());
+        if (!contribution.components().isEmpty()) {
+            sbomProducer.produce(new SbomContributionBuildItem(contribution));
+        }
+    }
+
+    static SbomContribution toSbomContribution(List<Dependency> deps) {
+        // Build components and index by Maven artifact key for dependency resolution
+        final List<ComponentDescriptor> components = new ArrayList<>(deps.size());
+        final Map<ArtifactKey, String> mavenKeyToBomRef = new HashMap<>(deps.size());
+        for (Dependency dep : deps) {
+            final ResolvedDependency rd = dep.resolvedDependency();
+            final ComponentDescriptor descriptor = ComponentDescriptor.builder()
+                    .setPurl(toNpmPurl(rd.getGroupId(), rd.getArtifactId(), rd.getVersion()))
+                    .setTopLevel(rd.isDirect())
+                    .build();
+            components.add(descriptor);
+            mavenKeyToBomRef.put(rd.getKey(), descriptor.getBomRef());
+        }
+
+        // Resolve dependency relationships from the Maven model
+        final List<ComponentDependencies> dependencies = new ArrayList<>();
+        for (Dependency dep : deps) {
+            final ResolvedDependency rd = dep.resolvedDependency();
+            final String parentBomRef = mavenKeyToBomRef.get(rd.getKey());
+            List<String> dependsOn = null;
+            for (ArtifactCoords child : rd.getDependencies()) {
+                final String childBomRef = mavenKeyToBomRef.get(child.getKey());
+                if (childBomRef != null) {
+                    if (dependsOn == null) {
+                        dependsOn = new ArrayList<>();
+                    }
+                    dependsOn.add(childBomRef);
+                }
+            }
+            if (dependsOn != null) {
+                dependencies.add(ComponentDependencies.of(parentBomRef, dependsOn));
+            }
+        }
+
+        return SbomContribution.of(components, dependencies);
+    }
+
+    static Purl toNpmPurl(String groupId, String artifactId, String version) {
+        String npmNamespace = null;
+        String npmName = artifactId;
+        if (groupId.startsWith(ORG_MVNPM_AT)) {
+            npmNamespace = "@" + groupId.substring(ORG_MVNPM_AT.length());
+        } else if ("org.webjars.npm".equals(groupId)) {
+            int scopeSep = artifactId.indexOf("__");
+            if (scopeSep > 0) {
+                npmNamespace = "@" + artifactId.substring(0, scopeSep);
+                npmName = artifactId.substring(scopeSep + 2);
+            }
+        }
+        return Purl.npm(npmNamespace, npmName, version);
     }
 
     private static Dependency toWebDep(ResolvedDependency d) {

--- a/common/deployment/src/test/java/io/quarkiverse/web/bundler/deployment/WebDependenciesSbomTest.java
+++ b/common/deployment/src/test/java/io/quarkiverse/web/bundler/deployment/WebDependenciesSbomTest.java
@@ -1,0 +1,166 @@
+package io.quarkiverse.web.bundler.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.mvnpm.esbuild.model.WebDependency;
+import io.quarkiverse.web.bundler.deployment.items.WebDependenciesBuildItem.Dependency;
+import io.quarkus.maven.dependency.ArtifactCoords;
+import io.quarkus.maven.dependency.ResolvedDependencyBuilder;
+import io.quarkus.paths.PathList;
+import io.quarkus.sbom.ComponentDependencies;
+import io.quarkus.sbom.ComponentDescriptor;
+import io.quarkus.sbom.Purl;
+import io.quarkus.sbom.SbomContribution;
+
+class WebDependenciesSbomTest {
+
+    @Test
+    void unscopedPackage() {
+        Purl purl = WebDependenciesProcessor.toNpmPurl("org.mvnpm", "jquery", "4.0.0");
+        assertEquals("npm", purl.getType());
+        assertNull(purl.getNamespace());
+        assertEquals("jquery", purl.getName());
+        assertEquals("4.0.0", purl.getVersion());
+        assertEquals("pkg:npm/jquery@4.0.0", purl.toString());
+    }
+
+    @Test
+    void scopedPackage() {
+        Purl purl = WebDependenciesProcessor.toNpmPurl("org.mvnpm.at.hotwired", "stimulus", "3.2.2");
+        assertEquals("npm", purl.getType());
+        assertEquals("@hotwired", purl.getNamespace());
+        assertEquals("stimulus", purl.getName());
+        assertEquals("3.2.2", purl.getVersion());
+        assertEquals("pkg:npm/%40hotwired/stimulus@3.2.2", purl.toString());
+    }
+
+    @Test
+    void scopedPackageWithDifferentNamespace() {
+        Purl purl = WebDependenciesProcessor.toNpmPurl("org.mvnpm.at.lit", "reactive-element", "2.0.4");
+        assertEquals("@lit", purl.getNamespace());
+        assertEquals("reactive-element", purl.getName());
+        assertEquals("2.0.4", purl.getVersion());
+    }
+
+    @Test
+    void nonMvnpmGroupId() {
+        Purl purl = WebDependenciesProcessor.toNpmPurl("org.webjars", "bootstrap", "5.3.0");
+        assertNull(purl.getNamespace());
+        assertEquals("bootstrap", purl.getName());
+        assertEquals("5.3.0", purl.getVersion());
+    }
+
+    @Test
+    void webjarsScopedPackage() {
+        Purl purl = WebDependenciesProcessor.toNpmPurl("org.webjars.npm", "types__node", "18.0.0");
+        assertEquals("@types", purl.getNamespace());
+        assertEquals("node", purl.getName());
+        assertEquals("18.0.0", purl.getVersion());
+        assertEquals("pkg:npm/%40types/node@18.0.0", purl.toString());
+    }
+
+    @Test
+    void webjarsUnscopedPackage() {
+        Purl purl = WebDependenciesProcessor.toNpmPurl("org.webjars.npm", "htmx.org", "1.9.0");
+        assertNull(purl.getNamespace());
+        assertEquals("htmx.org", purl.getName());
+        assertEquals("1.9.0", purl.getVersion());
+    }
+
+    @Test
+    void contributionIncludesDependencyRelationships() {
+        // bootstrap depends on @popperjs/core
+        Dependency bootstrap = dep("org.mvnpm", "bootstrap", "5.3.8",
+                List.of(ArtifactCoords.jar("org.mvnpm.at.popperjs", "core", "2.11.8")));
+        Dependency popperjs = dep("org.mvnpm.at.popperjs", "core", "2.11.8", List.of());
+        Dependency jquery = dep("org.mvnpm", "jquery", "4.0.0", List.of());
+
+        SbomContribution contribution = WebDependenciesProcessor.toSbomContribution(
+                List.of(bootstrap, popperjs, jquery));
+
+        // All 3 components present
+        Collection<ComponentDescriptor> components = contribution.components();
+        assertEquals(3, components.size());
+
+        // Verify dependency relationship: bootstrap -> @popperjs/core
+        Collection<ComponentDependencies> deps = contribution.dependencies();
+        assertEquals(1, deps.size(), "Only bootstrap should have dependencies");
+
+        ComponentDependencies bootstrapDeps = deps.iterator().next();
+        assertEquals("pkg:npm/bootstrap@5.3.8", bootstrapDeps.getBomRef());
+        assertEquals(1, bootstrapDeps.getDependsOn().size());
+        assertTrue(bootstrapDeps.getDependsOn().contains("pkg:npm/%40popperjs/core@2.11.8"));
+    }
+
+    @Test
+    void contributionExcludesUnknownDependencies() {
+        // bootstrap declares a dependency on @popperjs/core, but it's not in our web deps list
+        Dependency bootstrap = dep("org.mvnpm", "bootstrap", "5.3.8",
+                List.of(ArtifactCoords.jar("org.mvnpm.at.popperjs", "core", "2.11.8")));
+
+        SbomContribution contribution = WebDependenciesProcessor.toSbomContribution(List.of(bootstrap));
+
+        assertEquals(1, contribution.components().size());
+        assertTrue(contribution.dependencies().isEmpty(),
+                "No dependency entries when the child is not in the web deps list");
+    }
+
+    @Test
+    void directDependenciesMarkedTopLevel() {
+        // bootstrap is direct, popperjs is transitive (dependency of bootstrap)
+        Dependency bootstrap = dep("org.mvnpm", "bootstrap", "5.3.8",
+                List.of(ArtifactCoords.jar("org.mvnpm.at.popperjs", "core", "2.11.8")),
+                true);
+        Dependency popperjs = dep("org.mvnpm.at.popperjs", "core", "2.11.8",
+                List.of(), false);
+        Dependency jquery = dep("org.mvnpm", "jquery", "4.0.0",
+                List.of(), true);
+
+        SbomContribution contribution = WebDependenciesProcessor.toSbomContribution(
+                List.of(bootstrap, popperjs, jquery));
+
+        ComponentDescriptor bootstrapComp = contribution.components().stream()
+                .filter(c -> "bootstrap".equals(c.getName()))
+                .findFirst().orElseThrow();
+        assertTrue(bootstrapComp.isTopLevel(), "bootstrap is direct and should be top-level");
+
+        ComponentDescriptor popperjsComp = contribution.components().stream()
+                .filter(c -> "core".equals(c.getName()))
+                .findFirst().orElseThrow();
+        assertFalse(popperjsComp.isTopLevel(), "@popperjs/core is transitive and should not be top-level");
+
+        ComponentDescriptor jqueryComp = contribution.components().stream()
+                .filter(c -> "jquery".equals(c.getName()))
+                .findFirst().orElseThrow();
+        assertTrue(jqueryComp.isTopLevel(), "jquery is direct and should be top-level");
+    }
+
+    private static Dependency dep(String groupId, String artifactId, String version,
+            List<ArtifactCoords> dependencies) {
+        return dep(groupId, artifactId, version, dependencies, true);
+    }
+
+    private static Dependency dep(String groupId, String artifactId, String version,
+            List<ArtifactCoords> dependencies, boolean direct) {
+        var rd = ResolvedDependencyBuilder.newInstance()
+                .setGroupId(groupId)
+                .setArtifactId(artifactId)
+                .setVersion(version)
+                .setResolvedPaths(PathList.of(Path.of(artifactId + "-" + version + ".jar")))
+                .setDependencies(dependencies)
+                .setDirect(direct)
+                .build();
+        return new Dependency(rd, groupId + ":" + artifactId,
+                Path.of(artifactId + "-" + version + ".jar"),
+                WebDependency.WebDependencyType.MVNPM, direct);
+    }
+}

--- a/docs/modules/ROOT/pages/_includes/quarkus-project-scanner.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-project-scanner.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-project-scanner_quarkus-project-scanner-default-ignored-files]] [.property-path]##link:#quarkus-project-scanner_quarkus-project-scanner-default-ignored-files[`quarkus.project-scanner.default-ignored-files`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-project-scanner_quarkus-project-scanner-default-ignored-files]] [.property-path]##link:#quarkus-project-scanner_quarkus-project-scanner-default-ignored-files[`+++quarkus.project-scanner.default-ignored-files+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.project-scanner.default-ignored-files+++[]
 endif::add-copy-button-to-config-props[]
@@ -19,10 +19,10 @@ The default set of ignored files during project resources and files indexing.
 
 Entries may be prefixed with `regex:` or `glob:`. The default ignored files include:
 
- - `glob:++**++.DS_Store`
- - `glob:++**++Thumbs.db`
- - `glob:++**++.++*++~`
- - `glob:++**++.class`
+ * `glob:++**++.DS_Store`
+ * `glob:++**++Thumbs.db`
+ * `glob:++**++.++*++~`
+ * `glob:++**++.class`
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -33,9 +33,9 @@ Environment variable: `+++QUARKUS_PROJECT_SCANNER_DEFAULT_IGNORED_FILES+++`
 endif::add-copy-button-to-env-var[]
 --
 |list of string
-|`+++glob:**.DS_Store+++`, `+++glob:**Thumbs.db+++`, `+++glob:**.*~+++`, `+++glob:**.class+++`
+|glob:**.DS_Store, glob:**Thumbs.db, glob:**.*~, glob:**.class
 
-a|icon:lock[title=Fixed at build time] [[quarkus-project-scanner_quarkus-project-scanner-charset]] [.property-path]##link:#quarkus-project-scanner_quarkus-project-scanner-charset[`quarkus.project-scanner.charset`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-project-scanner_quarkus-project-scanner-charset]] [.property-path]##link:#quarkus-project-scanner_quarkus-project-scanner-charset[`+++quarkus.project-scanner.charset+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.project-scanner.charset+++[]
 endif::add-copy-button-to-config-props[]
@@ -54,9 +54,9 @@ Environment variable: `+++QUARKUS_PROJECT_SCANNER_CHARSET+++`
 endif::add-copy-button-to-env-var[]
 --
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/charset/Charset.html[Charset]
-|`+++UTF-8+++`
+|UTF-8
 
-a|icon:lock[title=Fixed at build time] [[quarkus-project-scanner_quarkus-project-scanner-indexed-files-warning-threshold]] [.property-path]##link:#quarkus-project-scanner_quarkus-project-scanner-indexed-files-warning-threshold[`quarkus.project-scanner.indexed-files-warning-threshold`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-project-scanner_quarkus-project-scanner-indexed-files-warning-threshold]] [.property-path]##link:#quarkus-project-scanner_quarkus-project-scanner-indexed-files-warning-threshold[`+++quarkus.project-scanner.indexed-files-warning-threshold+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.project-scanner.indexed-files-warning-threshold+++[]
 endif::add-copy-button-to-config-props[]
@@ -75,7 +75,7 @@ Environment variable: `+++QUARKUS_PROJECT_SCANNER_INDEXED_FILES_WARNING_THRESHOL
 endif::add-copy-button-to-env-var[]
 --
 |int
-|`+++10000+++`
+|10000
 
 |===
 

--- a/docs/modules/ROOT/pages/_includes/quarkus-project-scanner_quarkus.project-scanner.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-project-scanner_quarkus.project-scanner.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-project-scanner_quarkus-project-scanner-default-ignored-files]] [.property-path]##link:#quarkus-project-scanner_quarkus-project-scanner-default-ignored-files[`quarkus.project-scanner.default-ignored-files`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-project-scanner_quarkus-project-scanner-default-ignored-files]] [.property-path]##link:#quarkus-project-scanner_quarkus-project-scanner-default-ignored-files[`+++quarkus.project-scanner.default-ignored-files+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.project-scanner.default-ignored-files+++[]
 endif::add-copy-button-to-config-props[]
@@ -19,10 +19,10 @@ The default set of ignored files during project resources and files indexing.
 
 Entries may be prefixed with `regex:` or `glob:`. The default ignored files include:
 
- - `glob:++**++.DS_Store`
- - `glob:++**++Thumbs.db`
- - `glob:++**++.++*++~`
- - `glob:++**++.class`
+ * `glob:++**++.DS_Store`
+ * `glob:++**++Thumbs.db`
+ * `glob:++**++.++*++~`
+ * `glob:++**++.class`
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -33,9 +33,9 @@ Environment variable: `+++QUARKUS_PROJECT_SCANNER_DEFAULT_IGNORED_FILES+++`
 endif::add-copy-button-to-env-var[]
 --
 |list of string
-|`+++glob:**.DS_Store+++`, `+++glob:**Thumbs.db+++`, `+++glob:**.*~+++`, `+++glob:**.class+++`
+|glob:**.DS_Store, glob:**Thumbs.db, glob:**.*~, glob:**.class
 
-a|icon:lock[title=Fixed at build time] [[quarkus-project-scanner_quarkus-project-scanner-charset]] [.property-path]##link:#quarkus-project-scanner_quarkus-project-scanner-charset[`quarkus.project-scanner.charset`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-project-scanner_quarkus-project-scanner-charset]] [.property-path]##link:#quarkus-project-scanner_quarkus-project-scanner-charset[`+++quarkus.project-scanner.charset+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.project-scanner.charset+++[]
 endif::add-copy-button-to-config-props[]
@@ -54,9 +54,9 @@ Environment variable: `+++QUARKUS_PROJECT_SCANNER_CHARSET+++`
 endif::add-copy-button-to-env-var[]
 --
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/nio/charset/Charset.html[Charset]
-|`+++UTF-8+++`
+|UTF-8
 
-a|icon:lock[title=Fixed at build time] [[quarkus-project-scanner_quarkus-project-scanner-indexed-files-warning-threshold]] [.property-path]##link:#quarkus-project-scanner_quarkus-project-scanner-indexed-files-warning-threshold[`quarkus.project-scanner.indexed-files-warning-threshold`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-project-scanner_quarkus-project-scanner-indexed-files-warning-threshold]] [.property-path]##link:#quarkus-project-scanner_quarkus-project-scanner-indexed-files-warning-threshold[`+++quarkus.project-scanner.indexed-files-warning-threshold+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.project-scanner.indexed-files-warning-threshold+++[]
 endif::add-copy-button-to-config-props[]
@@ -75,7 +75,7 @@ Environment variable: `+++QUARKUS_PROJECT_SCANNER_INDEXED_FILES_WARNING_THRESHOL
 endif::add-copy-button-to-env-var[]
 --
 |int
-|`+++10000+++`
+|10000
 
 |===
 

--- a/docs/modules/ROOT/pages/_includes/quarkus-web-bundler-svelte.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-web-bundler-svelte.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler-svelte_quarkus-web-bundler-svelte-custom-element]] [.property-path]##link:#quarkus-web-bundler-svelte_quarkus-web-bundler-svelte-custom-element[`quarkus.web-bundler.svelte.custom-element`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler-svelte_quarkus-web-bundler-svelte-custom-element]] [.property-path]##link:#quarkus-web-bundler-svelte_quarkus-web-bundler-svelte-custom-element[`+++quarkus.web-bundler.svelte.custom-element+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.svelte.custom-element+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/_includes/quarkus-web-bundler-svelte_quarkus.web-bundler.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-web-bundler-svelte_quarkus.web-bundler.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler-svelte_quarkus-web-bundler-svelte-custom-element]] [.property-path]##link:#quarkus-web-bundler-svelte_quarkus-web-bundler-svelte-custom-element[`quarkus.web-bundler.svelte.custom-element`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler-svelte_quarkus-web-bundler-svelte-custom-element]] [.property-path]##link:#quarkus-web-bundler-svelte_quarkus-web-bundler-svelte-custom-element[`+++quarkus.web-bundler.svelte.custom-element+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.svelte.custom-element+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/_includes/quarkus-web-bundler-tailwindcss.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-web-bundler-tailwindcss.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-base]] [.property-path]##link:#quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-base[`quarkus.web-bundler.tailwindcss.base`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-base]] [.property-path]##link:#quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-base[`+++quarkus.web-bundler.tailwindcss.base+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.tailwindcss.base+++[]
 endif::add-copy-button-to-config-props[]
@@ -28,7 +28,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++the project root+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-pattern]] [.property-path]##link:#quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-pattern[`quarkus.web-bundler.tailwindcss.pattern`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-pattern]] [.property-path]##link:#quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-pattern[`+++quarkus.web-bundler.tailwindcss.pattern+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.tailwindcss.pattern+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/_includes/quarkus-web-bundler-tailwindcss_quarkus.web-bundler.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-web-bundler-tailwindcss_quarkus.web-bundler.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-base]] [.property-path]##link:#quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-base[`quarkus.web-bundler.tailwindcss.base`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-base]] [.property-path]##link:#quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-base[`+++quarkus.web-bundler.tailwindcss.base+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.tailwindcss.base+++[]
 endif::add-copy-button-to-config-props[]
@@ -28,7 +28,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++the project root+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-pattern]] [.property-path]##link:#quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-pattern[`quarkus.web-bundler.tailwindcss.pattern`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-pattern]] [.property-path]##link:#quarkus-web-bundler-tailwindcss_quarkus-web-bundler-tailwindcss-pattern[`+++quarkus.web-bundler.tailwindcss.pattern+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.tailwindcss.pattern+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/_includes/quarkus-web-bundler.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-web-bundler.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-web-root]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-web-root[`quarkus.web-bundler.web-root`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-web-root]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-web-root[`+++quarkus.web-bundler.web-root+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.web-root+++[]
 endif::add-copy-button-to-config-props[]
@@ -28,7 +28,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++web+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-local-web-dir]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-local-web-dir[`quarkus.web-bundler.local-web-dir`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-local-web-dir]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-local-web-dir[`+++quarkus.web-bundler.local-web-dir+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.local-web-dir+++[]
 endif::add-copy-button-to-config-props[]
@@ -49,7 +49,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-ignored-files]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-ignored-files[`quarkus.web-bundler.ignored-files`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-ignored-files]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-ignored-files[`+++quarkus.web-bundler.ignored-files+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.ignored-files+++[]
 endif::add-copy-button-to-config-props[]
@@ -74,7 +74,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle[`quarkus.web-bundler.bundle."bundle"`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle[`+++quarkus.web-bundler.bundle."bundle"+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle."bundle"+++[]
 endif::add-copy-button-to-config-props[]
@@ -96,7 +96,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-output]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-output[`quarkus.web-bundler.bundle."bundle".output`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-output]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-output[`+++quarkus.web-bundler.bundle."bundle".output+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle."bundle".output+++[]
 endif::add-copy-button-to-config-props[]
@@ -121,7 +121,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-dir]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-dir[`quarkus.web-bundler.bundle."bundle".dir`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-dir]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-dir[`+++quarkus.web-bundler.bundle."bundle".dir+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle."bundle".dir+++[]
 endif::add-copy-button-to-config-props[]
@@ -142,7 +142,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++the bundle map key+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-key]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-key[`quarkus.web-bundler.bundle."bundle".key`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-key]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-key[`+++quarkus.web-bundler.bundle."bundle".key+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle."bundle".key+++[]
 endif::add-copy-button-to-config-props[]
@@ -163,7 +163,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++the bundle map key+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-qute-tags]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-qute-tags[`quarkus.web-bundler.bundle."bundle".qute-tags`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-qute-tags]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-qute-tags[`+++quarkus.web-bundler.bundle."bundle".qute-tags+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle."bundle".qute-tags+++[]
 endif::add-copy-button-to-config-props[]
@@ -184,7 +184,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-path]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-path[`quarkus.web-bundler.bundle-path`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-path]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-path[`+++quarkus.web-bundler.bundle-path+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle-path+++[]
 endif::add-copy-button-to-config-props[]
@@ -205,7 +205,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++static/bundle+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-debug]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-debug[`quarkus.web-bundler.debug`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-debug]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-debug[`+++quarkus.web-bundler.debug+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.debug+++[]
 endif::add-copy-button-to-config-props[]
@@ -226,7 +226,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-sass]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-sass[`quarkus.web-bundler.sass`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-sass]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-sass[`+++quarkus.web-bundler.sass+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.sass+++[]
 endif::add-copy-button-to-config-props[]
@@ -247,7 +247,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-splitting]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-splitting[`quarkus.web-bundler.bundling.splitting`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-splitting]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-splitting[`+++quarkus.web-bundler.bundling.splitting+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.splitting+++[]
 endif::add-copy-button-to-config-props[]
@@ -268,7 +268,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-js]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-js[`quarkus.web-bundler.bundling.loaders.js`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-js]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-js[`+++quarkus.web-bundler.bundling.loaders.js+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.js+++[]
 endif::add-copy-button-to-config-props[]
@@ -289,7 +289,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++js+++`, `+++cjs+++`, `+++mjs+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-jsx]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-jsx[`quarkus.web-bundler.bundling.loaders.jsx`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-jsx]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-jsx[`+++quarkus.web-bundler.bundling.loaders.jsx+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.jsx+++[]
 endif::add-copy-button-to-config-props[]
@@ -310,7 +310,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++jsx+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-tsx]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-tsx[`quarkus.web-bundler.bundling.loaders.tsx`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-tsx]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-tsx[`+++quarkus.web-bundler.bundling.loaders.tsx+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.tsx+++[]
 endif::add-copy-button-to-config-props[]
@@ -331,7 +331,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++tsx+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-ts]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-ts[`quarkus.web-bundler.bundling.loaders.ts`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-ts]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-ts[`+++quarkus.web-bundler.bundling.loaders.ts+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.ts+++[]
 endif::add-copy-button-to-config-props[]
@@ -352,7 +352,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++ts+++`, `+++mts+++`, `+++cts+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-css]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-css[`quarkus.web-bundler.bundling.loaders.css`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-css]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-css[`+++quarkus.web-bundler.bundling.loaders.css+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.css+++[]
 endif::add-copy-button-to-config-props[]
@@ -373,7 +373,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++css+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-local-css]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-local-css[`quarkus.web-bundler.bundling.loaders.local-css`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-local-css]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-local-css[`+++quarkus.web-bundler.bundling.loaders.local-css+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.local-css+++[]
 endif::add-copy-button-to-config-props[]
@@ -394,7 +394,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++.module.css+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-global-css]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-global-css[`quarkus.web-bundler.bundling.loaders.global-css`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-global-css]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-global-css[`+++quarkus.web-bundler.bundling.loaders.global-css+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.global-css+++[]
 endif::add-copy-button-to-config-props[]
@@ -415,7 +415,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-file]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-file[`quarkus.web-bundler.bundling.loaders.file`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-file]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-file[`+++quarkus.web-bundler.bundling.loaders.file+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.file+++[]
 endif::add-copy-button-to-config-props[]
@@ -436,7 +436,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++aac+++`, `+++abw+++`, `+++arc+++`, `+++avif+++`, `+++avi+++`, `+++azw+++`, `+++bin+++`, `+++bmp+++`, `+++bz+++`, `+++bz2+++`, `+++cda+++`, `+++csv+++`, `+++yaml+++`, `+++yml+++`, `+++doc+++`, `+++docx+++`, `+++eot+++`, `+++epub+++`, `+++gz+++`, `+++gif+++`, `+++htm+++`, `+++html+++`, `+++ico+++`, `+++ics+++`, `+++jar+++`, `+++jpeg+++`, `+++jpg+++`, `+++jsonld+++`, `+++mid+++`, `+++midi+++`, `+++mp3+++`, `+++mp4+++`, `+++mpeg+++`, `+++mpkg+++`, `+++odp+++`, `+++ods+++`, `+++odt+++`, `+++oga+++`, `+++ogv+++`, `+++ogx+++`, `+++opus+++`, `+++otf+++`, `+++png+++`, `+++pdf+++`, `+++ppt+++`, `+++pptx+++`, `+++rar+++`, `+++rtf+++`, `+++svg+++`, `+++tar+++`, `+++tif+++`, `+++tiff+++`, `+++ttf+++`, `+++vsd+++`, `+++wav+++`, `+++weba+++`, `+++webm+++`, `+++webp+++`, `+++woff+++`, `+++woff2+++`, `+++xhtml+++`, `+++xls+++`, `+++xlsx+++`, `+++xml+++`, `+++xul+++`, `+++zip+++`, `+++3gp+++`, `+++3g2+++`, `+++7z+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-copy]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-copy[`quarkus.web-bundler.bundling.loaders.copy`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-copy]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-copy[`+++quarkus.web-bundler.bundling.loaders.copy+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.copy+++[]
 endif::add-copy-button-to-config-props[]
@@ -457,7 +457,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-base64]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-base64[`quarkus.web-bundler.bundling.loaders.base64`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-base64]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-base64[`+++quarkus.web-bundler.bundling.loaders.base64+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.base64+++[]
 endif::add-copy-button-to-config-props[]
@@ -478,7 +478,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-binary]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-binary[`quarkus.web-bundler.bundling.loaders.binary`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-binary]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-binary[`+++quarkus.web-bundler.bundling.loaders.binary+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.binary+++[]
 endif::add-copy-button-to-config-props[]
@@ -499,7 +499,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-data-url]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-data-url[`quarkus.web-bundler.bundling.loaders.data-url`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-data-url]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-data-url[`+++quarkus.web-bundler.bundling.loaders.data-url+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.data-url+++[]
 endif::add-copy-button-to-config-props[]
@@ -520,7 +520,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-empty]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-empty[`quarkus.web-bundler.bundling.loaders.empty`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-empty]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-empty[`+++quarkus.web-bundler.bundling.loaders.empty+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.empty+++[]
 endif::add-copy-button-to-config-props[]
@@ -541,7 +541,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-text]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-text[`quarkus.web-bundler.bundling.loaders.text`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-text]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-text[`+++quarkus.web-bundler.bundling.loaders.text+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.text+++[]
 endif::add-copy-button-to-config-props[]
@@ -562,7 +562,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++txt+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-json]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-json[`quarkus.web-bundler.bundling.loaders.json`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-json]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-json[`+++quarkus.web-bundler.bundling.loaders.json+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.json+++[]
 endif::add-copy-button-to-config-props[]
@@ -583,7 +583,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++json+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-external]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-external[`quarkus.web-bundler.bundling.external`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-external]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-external[`+++quarkus.web-bundler.bundling.external+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.external+++[]
 endif::add-copy-button-to-config-props[]
@@ -604,7 +604,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++{quarkus.http.root-path}static/*+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-source-map]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-source-map[`quarkus.web-bundler.bundling.source-map`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-source-map]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-source-map[`+++quarkus.web-bundler.bundling.source-map+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.source-map+++[]
 endif::add-copy-button-to-config-props[]
@@ -625,7 +625,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++linked+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-envs-envs]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-envs-envs[`quarkus.web-bundler.bundling.envs."envs"`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-envs-envs]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-envs-envs[`+++quarkus.web-bundler.bundling.envs."envs"+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.envs."envs"+++[]
 endif::add-copy-button-to-config-props[]
@@ -646,7 +646,7 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-dependencies-compile-only]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-dependencies-compile-only[`quarkus.web-bundler.dependencies.compile-only`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-dependencies-compile-only]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-dependencies-compile-only[`+++quarkus.web-bundler.dependencies.compile-only+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.dependencies.compile-only+++[]
 endif::add-copy-button-to-config-props[]
@@ -669,7 +669,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-dependencies-auto-import]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-dependencies-auto-import[`quarkus.web-bundler.dependencies.auto-import`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-dependencies-auto-import]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-dependencies-auto-import[`+++quarkus.web-bundler.dependencies.auto-import+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.dependencies.auto-import+++[]
 endif::add-copy-button-to-config-props[]
@@ -694,7 +694,7 @@ endif::add-copy-button-to-env-var[]
 a|`all`, `styles`, `none`
 |`+++none+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-browser-live-reload]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-browser-live-reload[`quarkus.web-bundler.browser-live-reload`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-browser-live-reload]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-browser-live-reload[`+++quarkus.web-bundler.browser-live-reload+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.browser-live-reload+++[]
 endif::add-copy-button-to-config-props[]
@@ -715,7 +715,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-node-modules]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-node-modules[`quarkus.web-bundler.node-modules`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-node-modules]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-node-modules[`+++quarkus.web-bundler.node-modules+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.node-modules+++[]
 endif::add-copy-button-to-config-props[]
@@ -736,7 +736,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++project root directory+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-redirect]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-redirect[`quarkus.web-bundler.bundle-redirect`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-redirect]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-redirect[`+++quarkus.web-bundler.bundle-redirect+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle-redirect+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/_includes/quarkus-web-bundler_quarkus.web-bundler.adoc
+++ b/docs/modules/ROOT/pages/_includes/quarkus-web-bundler_quarkus.web-bundler.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-web-root]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-web-root[`quarkus.web-bundler.web-root`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-web-root]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-web-root[`+++quarkus.web-bundler.web-root+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.web-root+++[]
 endif::add-copy-button-to-config-props[]
@@ -28,7 +28,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++web+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-local-web-dir]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-local-web-dir[`quarkus.web-bundler.local-web-dir`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-local-web-dir]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-local-web-dir[`+++quarkus.web-bundler.local-web-dir+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.local-web-dir+++[]
 endif::add-copy-button-to-config-props[]
@@ -49,7 +49,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-ignored-files]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-ignored-files[`quarkus.web-bundler.ignored-files`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-ignored-files]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-ignored-files[`+++quarkus.web-bundler.ignored-files+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.ignored-files+++[]
 endif::add-copy-button-to-config-props[]
@@ -74,7 +74,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle[`quarkus.web-bundler.bundle."bundle"`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle[`+++quarkus.web-bundler.bundle."bundle"+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle."bundle"+++[]
 endif::add-copy-button-to-config-props[]
@@ -96,7 +96,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-output]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-output[`quarkus.web-bundler.bundle."bundle".output`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-output]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-output[`+++quarkus.web-bundler.bundle."bundle".output+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle."bundle".output+++[]
 endif::add-copy-button-to-config-props[]
@@ -121,7 +121,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-dir]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-dir[`quarkus.web-bundler.bundle."bundle".dir`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-dir]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-dir[`+++quarkus.web-bundler.bundle."bundle".dir+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle."bundle".dir+++[]
 endif::add-copy-button-to-config-props[]
@@ -142,7 +142,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++the bundle map key+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-key]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-key[`quarkus.web-bundler.bundle."bundle".key`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-key]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-key[`+++quarkus.web-bundler.bundle."bundle".key+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle."bundle".key+++[]
 endif::add-copy-button-to-config-props[]
@@ -163,7 +163,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++the bundle map key+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-qute-tags]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-qute-tags[`quarkus.web-bundler.bundle."bundle".qute-tags`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-qute-tags]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-bundle-qute-tags[`+++quarkus.web-bundler.bundle."bundle".qute-tags+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle."bundle".qute-tags+++[]
 endif::add-copy-button-to-config-props[]
@@ -184,7 +184,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-path]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-path[`quarkus.web-bundler.bundle-path`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-path]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-path[`+++quarkus.web-bundler.bundle-path+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle-path+++[]
 endif::add-copy-button-to-config-props[]
@@ -205,7 +205,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++static/bundle+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-debug]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-debug[`quarkus.web-bundler.debug`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-debug]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-debug[`+++quarkus.web-bundler.debug+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.debug+++[]
 endif::add-copy-button-to-config-props[]
@@ -226,7 +226,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-sass]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-sass[`quarkus.web-bundler.sass`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-sass]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-sass[`+++quarkus.web-bundler.sass+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.sass+++[]
 endif::add-copy-button-to-config-props[]
@@ -247,7 +247,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-splitting]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-splitting[`quarkus.web-bundler.bundling.splitting`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-splitting]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-splitting[`+++quarkus.web-bundler.bundling.splitting+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.splitting+++[]
 endif::add-copy-button-to-config-props[]
@@ -268,7 +268,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-js]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-js[`quarkus.web-bundler.bundling.loaders.js`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-js]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-js[`+++quarkus.web-bundler.bundling.loaders.js+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.js+++[]
 endif::add-copy-button-to-config-props[]
@@ -289,7 +289,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++js+++`, `+++cjs+++`, `+++mjs+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-jsx]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-jsx[`quarkus.web-bundler.bundling.loaders.jsx`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-jsx]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-jsx[`+++quarkus.web-bundler.bundling.loaders.jsx+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.jsx+++[]
 endif::add-copy-button-to-config-props[]
@@ -310,7 +310,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++jsx+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-tsx]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-tsx[`quarkus.web-bundler.bundling.loaders.tsx`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-tsx]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-tsx[`+++quarkus.web-bundler.bundling.loaders.tsx+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.tsx+++[]
 endif::add-copy-button-to-config-props[]
@@ -331,7 +331,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++tsx+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-ts]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-ts[`quarkus.web-bundler.bundling.loaders.ts`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-ts]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-ts[`+++quarkus.web-bundler.bundling.loaders.ts+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.ts+++[]
 endif::add-copy-button-to-config-props[]
@@ -352,7 +352,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++ts+++`, `+++mts+++`, `+++cts+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-css]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-css[`quarkus.web-bundler.bundling.loaders.css`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-css]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-css[`+++quarkus.web-bundler.bundling.loaders.css+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.css+++[]
 endif::add-copy-button-to-config-props[]
@@ -373,7 +373,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++css+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-local-css]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-local-css[`quarkus.web-bundler.bundling.loaders.local-css`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-local-css]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-local-css[`+++quarkus.web-bundler.bundling.loaders.local-css+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.local-css+++[]
 endif::add-copy-button-to-config-props[]
@@ -394,7 +394,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++.module.css+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-global-css]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-global-css[`quarkus.web-bundler.bundling.loaders.global-css`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-global-css]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-global-css[`+++quarkus.web-bundler.bundling.loaders.global-css+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.global-css+++[]
 endif::add-copy-button-to-config-props[]
@@ -415,7 +415,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-file]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-file[`quarkus.web-bundler.bundling.loaders.file`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-file]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-file[`+++quarkus.web-bundler.bundling.loaders.file+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.file+++[]
 endif::add-copy-button-to-config-props[]
@@ -436,7 +436,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++aac+++`, `+++abw+++`, `+++arc+++`, `+++avif+++`, `+++avi+++`, `+++azw+++`, `+++bin+++`, `+++bmp+++`, `+++bz+++`, `+++bz2+++`, `+++cda+++`, `+++csv+++`, `+++yaml+++`, `+++yml+++`, `+++doc+++`, `+++docx+++`, `+++eot+++`, `+++epub+++`, `+++gz+++`, `+++gif+++`, `+++htm+++`, `+++html+++`, `+++ico+++`, `+++ics+++`, `+++jar+++`, `+++jpeg+++`, `+++jpg+++`, `+++jsonld+++`, `+++mid+++`, `+++midi+++`, `+++mp3+++`, `+++mp4+++`, `+++mpeg+++`, `+++mpkg+++`, `+++odp+++`, `+++ods+++`, `+++odt+++`, `+++oga+++`, `+++ogv+++`, `+++ogx+++`, `+++opus+++`, `+++otf+++`, `+++png+++`, `+++pdf+++`, `+++ppt+++`, `+++pptx+++`, `+++rar+++`, `+++rtf+++`, `+++svg+++`, `+++tar+++`, `+++tif+++`, `+++tiff+++`, `+++ttf+++`, `+++vsd+++`, `+++wav+++`, `+++weba+++`, `+++webm+++`, `+++webp+++`, `+++woff+++`, `+++woff2+++`, `+++xhtml+++`, `+++xls+++`, `+++xlsx+++`, `+++xml+++`, `+++xul+++`, `+++zip+++`, `+++3gp+++`, `+++3g2+++`, `+++7z+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-copy]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-copy[`quarkus.web-bundler.bundling.loaders.copy`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-copy]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-copy[`+++quarkus.web-bundler.bundling.loaders.copy+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.copy+++[]
 endif::add-copy-button-to-config-props[]
@@ -457,7 +457,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-base64]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-base64[`quarkus.web-bundler.bundling.loaders.base64`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-base64]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-base64[`+++quarkus.web-bundler.bundling.loaders.base64+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.base64+++[]
 endif::add-copy-button-to-config-props[]
@@ -478,7 +478,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-binary]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-binary[`quarkus.web-bundler.bundling.loaders.binary`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-binary]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-binary[`+++quarkus.web-bundler.bundling.loaders.binary+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.binary+++[]
 endif::add-copy-button-to-config-props[]
@@ -499,7 +499,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-data-url]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-data-url[`quarkus.web-bundler.bundling.loaders.data-url`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-data-url]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-data-url[`+++quarkus.web-bundler.bundling.loaders.data-url+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.data-url+++[]
 endif::add-copy-button-to-config-props[]
@@ -520,7 +520,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-empty]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-empty[`quarkus.web-bundler.bundling.loaders.empty`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-empty]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-empty[`+++quarkus.web-bundler.bundling.loaders.empty+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.empty+++[]
 endif::add-copy-button-to-config-props[]
@@ -541,7 +541,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-text]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-text[`quarkus.web-bundler.bundling.loaders.text`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-text]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-text[`+++quarkus.web-bundler.bundling.loaders.text+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.text+++[]
 endif::add-copy-button-to-config-props[]
@@ -562,7 +562,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++txt+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-json]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-json[`quarkus.web-bundler.bundling.loaders.json`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-json]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-loaders-json[`+++quarkus.web-bundler.bundling.loaders.json+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.loaders.json+++[]
 endif::add-copy-button-to-config-props[]
@@ -583,7 +583,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++json+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-external]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-external[`quarkus.web-bundler.bundling.external`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-external]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-external[`+++quarkus.web-bundler.bundling.external+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.external+++[]
 endif::add-copy-button-to-config-props[]
@@ -604,7 +604,7 @@ endif::add-copy-button-to-env-var[]
 |list of string
 |`+++{quarkus.http.root-path}static/*+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-source-map]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-source-map[`quarkus.web-bundler.bundling.source-map`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-source-map]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-source-map[`+++quarkus.web-bundler.bundling.source-map+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.source-map+++[]
 endif::add-copy-button-to-config-props[]
@@ -625,7 +625,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++linked+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-envs-envs]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-envs-envs[`quarkus.web-bundler.bundling.envs."envs"`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundling-envs-envs]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundling-envs-envs[`+++quarkus.web-bundler.bundling.envs."envs"+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundling.envs."envs"+++[]
 endif::add-copy-button-to-config-props[]
@@ -646,7 +646,7 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-dependencies-compile-only]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-dependencies-compile-only[`quarkus.web-bundler.dependencies.compile-only`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-dependencies-compile-only]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-dependencies-compile-only[`+++quarkus.web-bundler.dependencies.compile-only+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.dependencies.compile-only+++[]
 endif::add-copy-button-to-config-props[]
@@ -669,7 +669,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-dependencies-auto-import]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-dependencies-auto-import[`quarkus.web-bundler.dependencies.auto-import`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-dependencies-auto-import]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-dependencies-auto-import[`+++quarkus.web-bundler.dependencies.auto-import+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.dependencies.auto-import+++[]
 endif::add-copy-button-to-config-props[]
@@ -694,7 +694,7 @@ endif::add-copy-button-to-env-var[]
 a|`all`, `styles`, `none`
 |`+++none+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-browser-live-reload]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-browser-live-reload[`quarkus.web-bundler.browser-live-reload`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-browser-live-reload]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-browser-live-reload[`+++quarkus.web-bundler.browser-live-reload+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.browser-live-reload+++[]
 endif::add-copy-button-to-config-props[]
@@ -715,7 +715,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-node-modules]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-node-modules[`quarkus.web-bundler.node-modules`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-node-modules]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-node-modules[`+++quarkus.web-bundler.node-modules+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.node-modules+++[]
 endif::add-copy-button-to-config-props[]
@@ -736,7 +736,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |`+++project root directory+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-redirect]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-redirect[`quarkus.web-bundler.bundle-redirect`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-web-bundler_quarkus-web-bundler-bundle-redirect]] [.property-path]##link:#quarkus-web-bundler_quarkus-web-bundler-bundle-redirect[`+++quarkus.web-bundler.bundle-redirect+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.web-bundler.bundle-redirect+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/advanced-guides.adoc
+++ b/docs/modules/ROOT/pages/advanced-guides.adoc
@@ -298,6 +298,29 @@ WebJars are client-side web libraries (e.g. jQuery & Bootstrap) packaged into JA
 </dependency>
 ----
 
+[#sbom]
+== SBOM (Software Bill of Materials)
+
+When a Quarkus SBOM generating extension is present (such as `quarkus-cyclonedx`), web dependencies managed by the Web Bundler are automatically included in the generated SBOM with proper `pkg:npm/` Package URLs. Dependency relationships between web dependencies are also recorded.
+
+For example, a Maven dependency declared as:
+
+[source,xml]
+----
+<dependency>
+    <groupId>org.mvnpm</groupId>
+    <artifactId>jquery</artifactId>
+    <version>4.0.0</version>
+    <scope>provided</scope>
+</dependency>
+----
+
+will appear in the SBOM as a component with PURL `pkg:npm/jquery@4.0.0`.
+
+Scoped npm packages (e.g., `@hotwired/stimulus` declared as `org.mvnpm.at.hotwired:stimulus`) are also handled correctly, producing PURLs like `pkg:npm/%40hotwired/stimulus@3.2.2`.
+
+No additional configuration is required.
+
 [#bundle-paths]
 == Bundle Paths
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <esbuild-java.version>2.1.3</esbuild-java.version>
-        <quarkus.version>3.29.4</quarkus.version>
+        <quarkus.version>3.36.0</quarkus.version>
         <assertj-core.version>3.27.7</assertj-core.version>
         <quarkus-playwright.version>2.3.4</quarkus-playwright.version>
     </properties>


### PR DESCRIPTION
This change allows adding NPM libraries to SBOMs generated by Quarkus for vulnerability analysis.

This first commit updates the Quarkus version to 3.36.0, that introduced the SBOM contribution API.
The second one produces the necessary build item.