### PR TITLE
Allow mixed web/ root and web/app/ assets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,69 +15,87 @@ mvn install -DskipTests
 # Full build with integration tests
 mvn install
 
+# Run unit tests in core/deployment (uses QuarkusUnitTest with ShrinkWrap)
+mvn verify -pl core/deployment
+
 # Run a single integration test module
 mvn verify -pl integration-tests/core
 
 # Run a specific test class
 mvn verify -pl integration-tests/core -Dtest=BundleTest
 
+# Build the scanner/string-paths tools (independent parent POM)
+mvn install -f tools/pom.xml
+
 # Build docs
 mvn install -Pdocs
-
-# Install Playwright browsers (needed for browser-based tests)
-mvn quarkus:dev -Pplaywright-cli
 ```
 
 Java 17+ required. No Maven wrapper is included; use system Maven.
 
 ## Module Structure
 
-```
-scanner/                    # Reusable project resource scanning library
-common/
-  deployment/               # Core build-time processors (scanning, bundling, serving)
-  runtime/                  # Runtime classes (Bundle bean, config, live-reload handler)
-core/
-  spi/                      # Service Provider Interface for extension plugins
-  runtime/                  # (Being migrated to common/)
-  deployment/               # (Being migrated to common/)
-integrations/
-  svelte/                   # Svelte esbuild plugin integration
-  tailwindcss/              # TailwindCSS esbuild plugin integration
-  qute-components/          # Qute web components (template + script + style)
-integration-tests/
-  core/                     # Core bundler tests
-  svelte/                   # Svelte integration tests
-  tailwindcss/              # TailwindCSS integration tests
-```
+The project has two independent Maven trees (different parent POMs):
+
+**`tools/`** (parent: `quarkiverse-parent`, groupId: `io.quarkiverse.tools`) - Reusable libraries shared with other Quarkiverse extensions:
+- `scanner/` - Project resource scanning library (`ProjectScanner`, `ScanQuery`, `ProjectFile`)
+- `string-paths/` - Path string manipulation utilities (`StringPaths`)
+
+**Root** (parent: `quarkiverse-parent`, groupId: `io.quarkiverse.web-bundler`) - The extension itself:
+- `common/deployment/` - Core build-time processors (scanning, bundling, serving)
+- `common/runtime/` - Runtime classes (`Bundle` bean, config, recorders, live-reload handler)
+- `core/spi/` - Service Provider Interface for extension plugins (`WebBundlerWatchedDirBuildItem`)
+- `core/deployment/` - Unit tests using `QuarkusUnitTest` (being migrated to `common/`)
+- `core/runtime/` - (Being migrated to `common/`)
+- `integrations/svelte/` - Svelte esbuild plugin integration
+- `integrations/tailwindcss/` - TailwindCSS esbuild plugin integration
+- `integrations/qute-components/` - Qute web components (template + script + style)
+- `integration-tests/core/` - Integration tests using `@QuarkusTest` + RestAssured
+- `integration-tests/core/locker/` - POM-only module for locking web dependency versions
+- `integration-tests/svelte/`, `integration-tests/tailwindcss/`
 
 Each extension module follows the Quarkus pattern: `deployment/` for build-time logic (`@BuildStep` processors) and `runtime/` for runtime code (recorders, beans, config).
 
 ## Architecture: Bundling Pipeline
 
-The build pipeline executes as Quarkus build steps in this order:
+The build pipeline executes as Quarkus build steps. The key processors are in `common/deployment/`:
 
-1. **Scanning** - `ProjectScannerProcessor` builds an index of all web resources (from JARs, source dirs, local project dirs). The scanner is shared via `ProjectScannerBuildItem` and queried by subsequent processors.
+1. **Init** - `WebBundlerInitProcessor` declares scan config and sets up dev-mode file watching.
 
-2. **Asset Collection** - Three scanner processors collect assets:
-   - `BundleWebAssetsScannerProcessor` → `EntryPointBuildItem` (bundle entry points from `web/<entrypoint>/`)
-   - `StaticAssetsScannerProcessor` → `PublicAssetsBuildItem` (from `web/public/` and `web/static/`)
-   - `QuteTemplateAssetsScannerProcessor` → `QuteTemplatesBuildItem` (`.html` files in `web/`)
+2. **Scanning** - `ProjectScannerProcessor` (in `tools/scanner/`) builds an index of all web resources (from JARs, source dirs, local project dirs), shared via `ProjectScannerBuildItem`.
 
-3. **Dependency Installation** - `WebDependenciesProcessor` collects mvnpm/webjar dependencies and installs them into `node_modules/`.
+3. **Asset Collection** - Three scanner processors collect assets:
+   - `BundleWebAssetsScannerProcessor` -> `EntryPointBuildItem` (bundle entry points from `web/<entrypoint>/`)
+   - `StaticAssetsScannerProcessor` -> `PublicAssetsBuildItem` (from `web/public/` and `web/static/`)
+   - `QuteTemplateAssetsScannerProcessor` -> `QuteTemplatesBuildItem` (`.html` files in `web/`)
 
-4. **Bundle Preparation** - `BundlePrepareProcessor` creates esbuild configuration (`BundleOptions`): loaders, source maps, splitting, plugins, entry points → `ReadyForBundlingBuildItem`.
+4. **Dependency Installation** - `WebDependenciesProcessor` collects mvnpm/webjar dependencies and installs them into `node_modules/`.
 
-5. **Bundle Execution** - `BundleProcessor` (prod) or `DevBundleProcessor` (dev) calls esbuild-java to bundle → `GeneratedBundleBuildItem`.
+5. **Bundle Preparation** - `BundlePrepareProcessor` creates esbuild configuration (`BundleOptions`): loaders, source maps, splitting, plugins, entry points -> `ReadyForBundlingBuildItem`.
 
-6. **Resource Serving** - `GeneratedWebResourcesProcessor` registers bundled files as Quarkus static resources. In dev mode, sets up SSE live-reload at `/web-bundler/live`.
+6. **Bundle Execution** - `BundleProcessor` (prod) or `DevBundleProcessor` (dev) calls esbuild-java to bundle -> `GeneratedBundleBuildItem`.
+
+7. **Resource Serving** - `GeneratedWebResourcesProcessor` registers bundled files as Quarkus static resources. `StaticWebAssetsProcessor` and `QuteTemplateWebAssetsProcessor` handle their respective asset types. In dev mode, SSE live-reload is available at `/web-bundler/live`.
 
 ## Key Conventions
 
 - **Configuration prefix**: `quarkus.web-bundler` (see `WebBundlerConfig`), `quarkus.project-scanner` (see `ProjectScannerConfig`)
-- **Default web root**: `src/main/resources/web/` — entry points in `web/`, static assets in `web/public/`
-- **esbuild-java**: The bundling engine that is also maintained by the quarkus team (version in root pom.xml property `esbuild-java.version`)
-- **Plugin pattern**: Integrations contribute esbuild plugins via `WebBundlerEsbuildPluginBuiltItem`
+- **Default web root**: `src/main/resources/web/` with entry points in `web/`, static assets in `web/public/` and `web/static/`
+- **esbuild-java**: The bundling engine, also maintained by the Quarkus team (version in root `pom.xml` property `esbuild-java.version`)
 - **Build items**: `SimpleBuildItem` for singletons, `MultiBuildItem` for collections
-- **Tests**: Use `@QuarkusTest` + RestAssured for HTTP assertions + injected `Bundle` bean for mapping verification
-- **Scanner branch**: Active refactoring to extract scanner into a shared reusable module
+
+### Plugin SPI Pattern
+
+Integration plugins contribute esbuild plugins via `WebBundlerEsbuildPluginBuiltItem`. A plugin processor is minimal: produce a `FeatureBuildItem` and a `WebBundlerEsbuildPluginBuiltItem` wrapping an `EsBuildPlugin` instance. See `WebBundlerSvelteProcessor` for the canonical example.
+
+### Test Patterns
+
+Two test styles are used:
+
+- **Deployment tests** (`core/deployment/src/test/`): Use `QuarkusUnitTest` with `@RegisterExtension` and ShrinkWrap archives. Resources are added via `.addAsResource("web")`. These test the build pipeline in isolation. `QuarkusDevModeTest` tests hot-reload behavior.
+- **Integration tests** (`integration-tests/`): Use `@QuarkusTest` with RestAssured HTTP assertions and an injected `Bundle` bean to verify bundle mapping and resource serving.
+
+### Scanner Conventions
+
+- `indexPath` is a scanner-internal concept only, used within `tools/scanner/` code
+- Outside the scanner (e.g., `common/deployment/`), use `relativePath` since paths are typically converted to it

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,69 +15,87 @@ mvn install -DskipTests
 # Full build with integration tests
 mvn install
 
+# Run unit tests in core/deployment (uses QuarkusUnitTest with ShrinkWrap)
+mvn verify -pl core/deployment
+
 # Run a single integration test module
 mvn verify -pl integration-tests/core
 
 # Run a specific test class
 mvn verify -pl integration-tests/core -Dtest=BundleTest
 
+# Build the scanner/string-paths tools (independent parent POM)
+mvn install -f tools/pom.xml
+
 # Build docs
 mvn install -Pdocs
-
-# Install Playwright browsers (needed for browser-based tests)
-mvn quarkus:dev -Pplaywright-cli
 ```
 
-Java 17+ required. No Maven wrapper is included; use system Maven.
+Java 17+ required. A Maven wrapper (`mvnw`) is included in the repository.
 
 ## Module Structure
 
-```
-scanner/                    # Reusable project resource scanning library
-common/
-  deployment/               # Core build-time processors (scanning, bundling, serving)
-  runtime/                  # Runtime classes (Bundle bean, config, live-reload handler)
-core/
-  spi/                      # Service Provider Interface for extension plugins
-  runtime/                  # (Being migrated to common/)
-  deployment/               # (Being migrated to common/)
-integrations/
-  svelte/                   # Svelte esbuild plugin integration
-  tailwindcss/              # TailwindCSS esbuild plugin integration
-  qute-components/          # Qute web components (template + script + style)
-integration-tests/
-  core/                     # Core bundler tests
-  svelte/                   # Svelte integration tests
-  tailwindcss/              # TailwindCSS integration tests
-```
+The project has two independent Maven aggregator POMs (same parent `quarkiverse-parent`, different groupIds):
+
+**`tools/`** (parent: `quarkiverse-parent`, groupId: `io.quarkiverse.tools`) - Reusable libraries shared with other Quarkiverse extensions:
+- `scanner/` - Project resource scanning library (`ProjectScanner`, `ScanQuery`, `ProjectFile`)
+- `string-paths/` - Path string manipulation utilities (`StringPaths`)
+
+**Root** (parent: `quarkiverse-parent`, groupId: `io.quarkiverse.web-bundler`) - The extension itself:
+- `common/deployment/` - Core build-time processors (scanning, bundling, serving)
+- `common/runtime/` - Runtime classes (`Bundle` bean, config, recorders, live-reload handler)
+- `core/spi/` - Service Provider Interface for extension plugins (`WebBundlerWatchedDirBuildItem`)
+- `core/deployment/` - Unit tests using `QuarkusUnitTest` (being migrated to `common/`)
+- `core/runtime/` - (Being migrated to `common/`)
+- `integrations/svelte/` - Svelte esbuild plugin integration
+- `integrations/tailwindcss/` - TailwindCSS esbuild plugin integration
+- `integrations/qute-components/` - Qute web components (template + script + style)
+- `integration-tests/core/` - Integration tests using `@QuarkusTest` + RestAssured
+- `integration-tests/core/locker/` - POM-only module for locking web dependency versions
+- `integration-tests/svelte/`, `integration-tests/tailwindcss/`
 
 Each extension module follows the Quarkus pattern: `deployment/` for build-time logic (`@BuildStep` processors) and `runtime/` for runtime code (recorders, beans, config).
 
 ## Architecture: Bundling Pipeline
 
-The build pipeline executes as Quarkus build steps in this order:
+The build pipeline executes as Quarkus build steps. The key processors are in `common/deployment/`:
 
-1. **Scanning** - `ProjectScannerProcessor` builds an index of all web resources (from JARs, source dirs, local project dirs). The scanner is shared via `ProjectScannerBuildItem` and queried by subsequent processors.
+1. **Init** - `WebBundlerInitProcessor` declares scan config and sets up dev-mode file watching.
 
-2. **Asset Collection** - Three scanner processors collect assets:
-   - `BundleWebAssetsScannerProcessor` → `EntryPointBuildItem` (bundle entry points from `web/<entrypoint>/`)
-   - `StaticAssetsScannerProcessor` → `PublicAssetsBuildItem` (from `web/public/` and `web/static/`)
-   - `QuteTemplateAssetsScannerProcessor` → `QuteTemplatesBuildItem` (`.html` files in `web/`)
+2. **Scanning** - `ProjectScannerProcessor` (in `tools/scanner/`) builds an index of all web resources (from JARs, source dirs, local project dirs), shared via `ProjectScannerBuildItem`.
 
-3. **Dependency Installation** - `WebDependenciesProcessor` collects mvnpm/webjar dependencies and installs them into `node_modules/`.
+3. **Asset Collection** - Three scanner processors collect assets:
+   - `BundleWebAssetsScannerProcessor` -> `EntryPointBuildItem` (bundle entry points from `web/<entrypoint>/`)
+   - `StaticAssetsScannerProcessor` -> `PublicAssetsBuildItem` (from `web/public/` and `web/static/`)
+   - `QuteTemplateAssetsScannerProcessor` -> `QuteTemplatesBuildItem` (`.html` files in `web/`)
 
-4. **Bundle Preparation** - `BundlePrepareProcessor` creates esbuild configuration (`BundleOptions`): loaders, source maps, splitting, plugins, entry points → `ReadyForBundlingBuildItem`.
+4. **Dependency Installation** - `WebDependenciesProcessor` collects mvnpm/webjar dependencies and installs them into `node_modules/`.
 
-5. **Bundle Execution** - `BundleProcessor` (prod) or `DevBundleProcessor` (dev) calls esbuild-java to bundle → `GeneratedBundleBuildItem`.
+5. **Bundle Preparation** - `BundlePrepareProcessor` creates esbuild configuration (`BundleOptions`): loaders, source maps, splitting, plugins, entry points -> `ReadyForBundlingBuildItem`.
 
-6. **Resource Serving** - `GeneratedWebResourcesProcessor` registers bundled files as Quarkus static resources. In dev mode, sets up SSE live-reload at `/web-bundler/live`.
+6. **Bundle Execution** - `BundleProcessor` (prod) or `DevBundleProcessor` (dev) calls esbuild-java to bundle -> `GeneratedBundleBuildItem`.
+
+7. **Resource Serving** - `GeneratedWebResourcesProcessor` registers bundled files as Quarkus static resources. `StaticWebAssetsProcessor` and `QuteTemplateWebAssetsProcessor` handle their respective asset types. In dev mode, SSE live-reload is available at `/web-bundler/live`.
 
 ## Key Conventions
 
 - **Configuration prefix**: `quarkus.web-bundler` (see `WebBundlerConfig`), `quarkus.project-scanner` (see `ProjectScannerConfig`)
-- **Default web root**: `src/main/resources/web/` — entry points in `web/`, static assets in `web/public/`
-- **esbuild-java**: The bundling engine that is also maintained by the quarkus team (version in root pom.xml property `esbuild-java.version`)
-- **Plugin pattern**: Integrations contribute esbuild plugins via `WebBundlerEsbuildPluginBuiltItem`
+- **Default web root**: `src/main/resources/web/` with entry points in `web/`, static assets in `web/public/` and `web/static/`
+- **esbuild-java**: The bundling engine, also maintained by the Quarkus team (version in root `pom.xml` property `esbuild-java.version`)
 - **Build items**: `SimpleBuildItem` for singletons, `MultiBuildItem` for collections
-- **Tests**: Use `@QuarkusTest` + RestAssured for HTTP assertions + injected `Bundle` bean for mapping verification
-- **Scanner branch**: Active refactoring to extract scanner into a shared reusable module
+
+### Plugin SPI Pattern
+
+Integration plugins contribute esbuild plugins via `WebBundlerEsbuildPluginBuiltItem`. A plugin processor is minimal: produce a `FeatureBuildItem` and a `WebBundlerEsbuildPluginBuiltItem` wrapping an `EsBuildPlugin` instance. See `WebBundlerSvelteProcessor` for the canonical example.
+
+### Test Patterns
+
+Two test styles are used:
+
+- **Deployment tests** (`core/deployment/src/test/`): Use `QuarkusUnitTest` with `@RegisterExtension` and ShrinkWrap archives. Resources are added via `.addAsResource("web")`. These test the build pipeline in isolation. `QuarkusDevModeTest` tests hot-reload behavior.
+- **Integration tests** (`integration-tests/`): Use `@QuarkusTest` with RestAssured HTTP assertions and an injected `Bundle` bean to verify bundle mapping and resource serving.
+
+### Scanner Conventions
+
+- `indexPath` is a scanner-internal concept only, used within `tools/scanner/` code
+- Outside the scanner (e.g., `common/deployment/`), use `relativePath` since paths are typically converted to it

--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/BundlePrepareProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/BundlePrepareProcessor.java
@@ -185,9 +185,14 @@ public class BundlePrepareProcessor {
                     .valueOf(config.dependencies().autoImport().mode().toString());
             for (EntryPointBuildItem entryPoint : entryPoints) {
                 final List<String> scripts = new ArrayList<>();
+                final String entryPointFullDir = config.prefixWithWebRoot(entryPoint.dir());
 
                 for (BundleWebAsset webAsset : entryPoint.assets()) {
-                    String destination = webAsset.indexPath();
+                    // For the default entry point, root-scoped assets use scopedPath to
+                    // place them under web/app/ alongside the app-scoped assets
+                    String destination = DEFAULT_ENTRY_POINT_KEY.equals(entryPoint.key())
+                            ? join(entryPointFullDir, webAsset.scopedPath())
+                            : webAsset.indexPath();
                     final Path scriptPath = targetDir.webBundler().resolve(destination);
                     createAsset(launchMode, browserLiveReload, watchedLinks, watchedFiles, webAsset, scriptPath);
                     // Manual assets are supposed to be imported by the entry point

--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/BundleWebAssetsScannerProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/BundleWebAssetsScannerProcessor.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import org.jboss.logging.Logger;
@@ -30,7 +29,6 @@ import io.quarkiverse.web.bundler.deployment.items.DevWatcherHistoryBuildItem;
 import io.quarkiverse.web.bundler.deployment.items.EntryPointBuildItem;
 import io.quarkiverse.web.bundler.deployment.items.EntryPointBuildItem.EntryPoint;
 import io.quarkiverse.web.bundler.deployment.items.WebBundlerTargetDirBuildItem;
-import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -91,10 +89,17 @@ class BundleWebAssetsScannerProcessor {
         LOGGER.debug("Web Bundler scan - Bundles: start");
         final Map<String, EntryPoint> entryPoints = new TreeMap<>();
 
-        // This is legacy support for web/app dir
-        boolean appDir = checkAppDir(config);
+        final Map<String, EntryPointConfig> entryPointConfigs = config.bundleWithDefault();
 
-        for (Map.Entry<String, EntryPointConfig> e : config.bundleWithDefault(appDir).entrySet()) {
+        // Collect all entry point directory names for root-scan exclusion
+        final List<String> allEntryPointDirs = new ArrayList<>();
+        for (Map.Entry<String, EntryPointConfig> e : entryPointConfigs.entrySet()) {
+            if (e.getValue().enabled()) {
+                allEntryPointDirs.add(e.getValue().effectiveDir(e.getKey()));
+            }
+        }
+
+        for (Map.Entry<String, EntryPointConfig> e : entryPointConfigs.entrySet()) {
             if (e.getValue().enabled()) {
 
                 final String entryPointKey = e.getValue().effectiveKey(e.getKey());
@@ -102,25 +107,45 @@ class BundleWebAssetsScannerProcessor {
                 entryPoints.putIfAbsent(entryPointKey,
                         new EntryPoint(entryPointKey, dir, e.getValue().output(), new ArrayList<>()));
 
-                // The regex is for all files but .html
                 final String fullDir = config.prefixWithWebRoot(dir);
                 final List<ProjectFile> assets = scanner.query()
                         .scopeDirs(fullDir)
                         .addExcluded(config.ignoredFilesOrEmpty())
-                        .addExcluded(
-                                dir.isEmpty()
-                                        ? List.of("glob:templates/**", "glob:public/**", "glob:static/**", "glob:**.html",
-                                                "glob:tsconfig.json")
-                                        : List.of("glob:**.html"))
+                        .addExcluded(List.of("glob:**.html"))
                         .list();
+
+                // For the default "app" entry point, also collect loose root-level files
+                final List<ProjectFile> allAssets;
+                if (DEFAULT_ENTRY_POINT_KEY.equals(entryPointKey)) {
+                    List<String> rootExclusions = new ArrayList<>(
+                            List.of("glob:templates/**", "glob:public/**", "glob:static/**",
+                                    "glob:**.html", "glob:tsconfig.json"));
+                    for (String epDir : allEntryPointDirs) {
+                        rootExclusions.add("glob:" + epDir + "/**");
+                    }
+                    final List<ProjectFile> rootAssets = scanner.query()
+                            .scopeDirs(config.webRoot())
+                            .addExcluded(config.ignoredFilesOrEmpty())
+                            .addExcluded(rootExclusions)
+                            .list();
+                    allAssets = new ArrayList<>(assets.size() + rootAssets.size());
+                    allAssets.addAll(assets);
+                    allAssets.addAll(rootAssets);
+                } else {
+                    allAssets = assets;
+                }
+
+                // Prefer index.* from the entry point dir, fall back to root
                 final Optional<ProjectFile> entryPoint = assets.stream()
                         .filter(w -> w.scopedPath().startsWith("index."))
-                        .findAny();
-                for (ProjectFile webAsset : assets) {
+                        .findAny()
+                        .or(() -> allAssets.stream()
+                                .filter(w -> w.scopedPath().startsWith("index."))
+                                .findAny());
+
+                for (ProjectFile webAsset : allAssets) {
                     BundleType bundleType = entryPoint
-                            // If it's not the entry point we consider it as a manual asset (imported by the entry point)
                             .map(ep -> webAsset.equals(ep) ? BundleType.INDEX : BundleType.MANUAL)
-                            // When there is no entry point we consider it as a auto asset unless it's a sass import file (_*.sass)
                             .orElse(isImportSassFile(webAsset.scopedPath()) ? BundleType.MANUAL : BundleType.AUTO);
                     entryPoints.get(entryPointKey).assets().add(new BundleWebAsset(webAsset, bundleType));
                 }
@@ -130,7 +155,6 @@ class BundleWebAssetsScannerProcessor {
         if (entryPoints.size() == 1 && entryPoints.get(DEFAULT_ENTRY_POINT_KEY) != null
                 && entryPoints.get(DEFAULT_ENTRY_POINT_KEY).assets().isEmpty()) {
 
-            // Let's create an empty app javascript when there is nothing provided
             final String appJsResource = StringPaths.join(config.webRoot(), "app.js");
             final byte[] appJsContent = "".getBytes(StandardCharsets.UTF_8);
             generatedResourceProducer.produce(new GeneratedResourceBuildItem(appJsResource, appJsContent));
@@ -153,24 +177,6 @@ class BundleWebAssetsScannerProcessor {
                 bundleConfigWebAssets);
         produceWebAssets(bundles, bundleConfigAssets, context);
         LOGGER.debugf("Web Bundler scan - Bundles: %d entrypoints found", entryPoints.size());
-    }
-
-    private static boolean checkAppDir(WebBundlerConfig config) {
-        AtomicBoolean appDir = new AtomicBoolean(false);
-        QuarkusClassLoader.visitRuntimeResources(config.webRoot(), p -> {
-            final Path appDirPath = p.getPath().resolve("app");
-            if (!Files.isDirectory(appDirPath)) {
-                appDir.set(false);
-                return;
-            }
-            try (var entries = Files.list(appDirPath)) {
-                final boolean app = Files.isDirectory(appDirPath) && entries.findFirst().isPresent();
-                appDir.set(app);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
-        return appDir.get();
     }
 
     private static boolean isImportSassFile(String resourceName) {

--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/BundleWebAssetsScannerProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/BundleWebAssetsScannerProcessor.java
@@ -115,8 +115,9 @@ class BundleWebAssetsScannerProcessor {
                         .list();
 
                 // For the default "app" entry point, also collect loose root-level files
+                // (only once for the canonical 'app' entry, not for other dirs merged into key 'app')
                 final List<ProjectFile> allAssets;
-                if (DEFAULT_ENTRY_POINT_KEY.equals(entryPointKey)) {
+                if (DEFAULT_ENTRY_POINT_KEY.equals(entryPointKey) && DEFAULT_ENTRY_POINT_KEY.equals(e.getKey())) {
                     List<String> rootExclusions = new ArrayList<>(
                             List.of("glob:templates/**", "glob:public/**", "glob:static/**",
                                     "glob:**.html", "glob:tsconfig.json"));

--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/BundleWebAssetsScannerProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/BundleWebAssetsScannerProcessor.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 import org.jboss.logging.Logger;
@@ -30,7 +29,6 @@ import io.quarkiverse.web.bundler.deployment.items.DevWatcherHistoryBuildItem;
 import io.quarkiverse.web.bundler.deployment.items.EntryPointBuildItem;
 import io.quarkiverse.web.bundler.deployment.items.EntryPointBuildItem.EntryPoint;
 import io.quarkiverse.web.bundler.deployment.items.WebBundlerTargetDirBuildItem;
-import io.quarkus.bootstrap.classloading.QuarkusClassLoader;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -91,10 +89,9 @@ class BundleWebAssetsScannerProcessor {
         LOGGER.debug("Web Bundler scan - Bundles: start");
         final Map<String, EntryPoint> entryPoints = new TreeMap<>();
 
-        // This is legacy support for web/app dir
-        boolean appDir = checkAppDir(config);
+        final Map<String, EntryPointConfig> entryPointConfigs = config.bundleWithDefault();
 
-        for (Map.Entry<String, EntryPointConfig> e : config.bundleWithDefault(appDir).entrySet()) {
+        for (Map.Entry<String, EntryPointConfig> e : entryPointConfigs.entrySet()) {
             if (e.getValue().enabled()) {
 
                 final String entryPointKey = e.getValue().effectiveKey(e.getKey());
@@ -102,25 +99,47 @@ class BundleWebAssetsScannerProcessor {
                 entryPoints.putIfAbsent(entryPointKey,
                         new EntryPoint(entryPointKey, dir, e.getValue().output(), new ArrayList<>()));
 
-                // The regex is for all files but .html
                 final String fullDir = config.prefixWithWebRoot(dir);
                 final List<ProjectFile> assets = scanner.query()
                         .scopeDirs(fullDir)
                         .addExcluded(config.ignoredFilesOrEmpty())
-                        .addExcluded(
-                                dir.isEmpty()
-                                        ? List.of("glob:templates/**", "glob:public/**", "glob:static/**", "glob:**.html",
-                                                "glob:tsconfig.json")
-                                        : List.of("glob:**.html"))
+                        .addExcluded(List.of("glob:**.html"))
                         .list();
+
+                // When only the default "app" entry point exists, also collect loose root-level
+                // files and bundle them as part of "app". The size == 1 guard ensures we don't
+                // accidentally pull files from other configured entry-point directories, since
+                // only "glob:app/**" is excluded from the root scan.
+                final List<ProjectFile> allAssets;
+                if (DEFAULT_ENTRY_POINT_KEY.equals(entryPointKey) && DEFAULT_ENTRY_POINT_KEY.equals(e.getKey())
+                        && entryPointConfigs.size() == 1) {
+                    final List<ProjectFile> rootAssets = scanner.query()
+                            .scopeDirs(config.webRoot())
+                            .addExcluded(config.ignoredFilesOrEmpty())
+                            .addExcluded(List.of("glob:templates/**", "glob:public/**", "glob:static/**",
+                                    "glob:**.html", "glob:tsconfig.json",
+                                    "glob:" + DEFAULT_ENTRY_POINT_KEY + "/**"))
+                            .list();
+                    // Root assets are added after app assets so that user root files
+                    // (ROOT_APPLICATION_RESOURCE) override theme app files (DEPENDENCY_RESOURCE)
+                    allAssets = new ArrayList<>(assets.size() + rootAssets.size());
+                    allAssets.addAll(assets);
+                    allAssets.addAll(rootAssets);
+                } else {
+                    allAssets = assets;
+                }
+
+                // Prefer index.* from the entry point dir, fall back to root
                 final Optional<ProjectFile> entryPoint = assets.stream()
                         .filter(w -> w.scopedPath().startsWith("index."))
-                        .findAny();
-                for (ProjectFile webAsset : assets) {
+                        .findAny()
+                        .or(() -> allAssets.stream()
+                                .filter(w -> w.scopedPath().startsWith("index."))
+                                .findAny());
+
+                for (ProjectFile webAsset : allAssets) {
                     BundleType bundleType = entryPoint
-                            // If it's not the entry point we consider it as a manual asset (imported by the entry point)
                             .map(ep -> webAsset.equals(ep) ? BundleType.INDEX : BundleType.MANUAL)
-                            // When there is no entry point we consider it as a auto asset unless it's a sass import file (_*.sass)
                             .orElse(isImportSassFile(webAsset.scopedPath()) ? BundleType.MANUAL : BundleType.AUTO);
                     entryPoints.get(entryPointKey).assets().add(new BundleWebAsset(webAsset, bundleType));
                 }
@@ -130,7 +149,6 @@ class BundleWebAssetsScannerProcessor {
         if (entryPoints.size() == 1 && entryPoints.get(DEFAULT_ENTRY_POINT_KEY) != null
                 && entryPoints.get(DEFAULT_ENTRY_POINT_KEY).assets().isEmpty()) {
 
-            // Let's create an empty app javascript when there is nothing provided
             final String appJsResource = StringPaths.join(config.webRoot(), "app.js");
             final byte[] appJsContent = "".getBytes(StandardCharsets.UTF_8);
             generatedResourceProducer.produce(new GeneratedResourceBuildItem(appJsResource, appJsContent));
@@ -153,24 +171,6 @@ class BundleWebAssetsScannerProcessor {
                 bundleConfigWebAssets);
         produceWebAssets(bundles, bundleConfigAssets, context);
         LOGGER.debugf("Web Bundler scan - Bundles: %d entrypoints found", entryPoints.size());
-    }
-
-    private static boolean checkAppDir(WebBundlerConfig config) {
-        AtomicBoolean appDir = new AtomicBoolean(false);
-        QuarkusClassLoader.visitRuntimeResources(config.webRoot(), p -> {
-            final Path appDirPath = p.getPath().resolve("app");
-            if (!Files.isDirectory(appDirPath)) {
-                appDir.set(false);
-                return;
-            }
-            try (var entries = Files.list(appDirPath)) {
-                final boolean app = Files.isDirectory(appDirPath) && entries.findFirst().isPresent();
-                appDir.set(app);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
-        return appDir.get();
     }
 
     private static boolean isImportSassFile(String resourceName) {

--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/config/WebBundlerConfig.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/config/WebBundlerConfig.java
@@ -70,11 +70,10 @@ public interface WebBundlerConfig {
     @ConfigDocDefault("if not overridden, by default, 'app' directory will be bundled.")
     Map<String, EntryPointConfig> bundle();
 
-    default Map<String, EntryPointConfig> bundleWithDefault(boolean appDir) {
+    default Map<String, EntryPointConfig> bundleWithDefault() {
         Map<String, EntryPointConfig> conf = new HashMap<>(bundle());
         if (!conf.containsKey(DEFAULT_ENTRY_POINT_KEY)) {
-            // When the config is not empty, default app entrypoint can only be in web/app/ dir
-            conf.put(DEFAULT_ENTRY_POINT_KEY, new ConfiguredEntryPoint(!appDir && conf.isEmpty() ? "" : DEFAULT_ENTRY_POINT_KEY,
+            conf.put(DEFAULT_ENTRY_POINT_KEY, new ConfiguredEntryPoint(DEFAULT_ENTRY_POINT_KEY,
                     DEFAULT_ENTRY_POINT_KEY, DEFAULT_ENTRY_POINT_KEY, true));
         }
         return conf;

--- a/core/deployment/src/test/java/io/quarkiverse/web/bundler/test/WebBundlerMixedAssetsTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/web/bundler/test/WebBundlerMixedAssetsTest.java
@@ -1,0 +1,38 @@
+package io.quarkiverse.web.bundler.test;
+
+import jakarta.inject.Inject;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.web.bundler.runtime.Bundle;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+
+public class WebBundlerMixedAssetsTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .withConfigurationResource("application-mixed.properties")
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addAsResource("mixed", "web"));
+
+    @Inject
+    Bundle bundle;
+
+    @Test
+    public void testMixedRootAndAppDirAssets() {
+        final String appCss = bundle.style("app");
+        org.junit.jupiter.api.Assertions.assertNotNull(appCss, "app CSS bundle should exist");
+
+        RestAssured.given()
+                .basePath("")
+                .get(appCss)
+                .then()
+                .statusCode(200)
+                .body(org.hamcrest.Matchers.containsString("font-family"))
+                .body(org.hamcrest.Matchers.containsString("color"));
+    }
+}

--- a/core/deployment/src/test/resources/application-mixed.properties
+++ b/core/deployment/src/test/resources/application-mixed.properties
@@ -1,0 +1,3 @@
+quarkus.log.category."io.quarkiverse.web.bundler".level=DEBUG
+quarkus.log.category."io.mvnpm.esbuild".level=DEBUG
+quarkus.http.test-port=0

--- a/core/deployment/src/test/resources/mixed/app/lib-style.css
+++ b/core/deployment/src/test/resources/mixed/app/lib-style.css
@@ -1,0 +1,1 @@
+body { font-family: sans-serif; }

--- a/core/deployment/src/test/resources/mixed/index.html
+++ b/core/deployment/src/test/resources/mixed/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+<head><title>Mixed Test</title></head>
+<body><p>Hello Mixed!</p></body>
+</html>

--- a/core/deployment/src/test/resources/mixed/root-style.css
+++ b/core/deployment/src/test/resources/mixed/root-style.css
@@ -1,0 +1,1 @@
+h1 { color: red; }

--- a/docs/modules/ROOT/pages/advanced-guides.adoc
+++ b/docs/modules/ROOT/pages/advanced-guides.adoc
@@ -125,12 +125,17 @@ quarkus.web-bundler.bundle.baz.key=foo
 <1> Bundle `src/main/resources/web/foo/...` and `src/main/resources/web/baz/...` together into `/static/bundle/foo-[hash].[ext]`
 <2> Bundle `src/main/resources/web/my-dir/...` into `/static/bundle/my-key-[hash].[ext]`
 
+[NOTE]
+====
+Scripts and styles located at the root of the web directory (e.g. `src/main/resources/web/style.css`) are automatically bundled as part of the default `app` entry point, as if they were in `web/app/`. This makes it easy to get started without creating the `web/app/` subdirectory.
+====
+
 [IMPORTANT]
 ====
-As soon as one or more entry-points are configured:
+As soon as one or more custom entry-points are configured:
 
-* Scripts and styles located at the root of the web directory will not be bundled. To keep things organized, move them to the web/app directory (or remove them if unnecessary).
-* When multiple output entry points exist, shared code and web dependencies are extracted into a separate file which is auto-imported in `{#bundle /}`. This ensures that if a user navigates from one page to another, they don’t need to download all the JavaScript for the second page again—shared parts are already cached by the browser.
+* Scripts and styles located at the root of the web directory will not be bundled. To keep things organized, move them to the `web/app/` directory (or remove them if unnecessary).
+* When multiple output entry points exist, shared code and web dependencies are extracted into a separate file which is auto-imported in `{#bundle /}`. This ensures that if a user navigates from one page to another, they don’t need to download all the JavaScript for the second page again, as shared parts are already cached by the browser.
 ====
 
 

--- a/integrations/qute-components/deployment/src/main/java/io/quarkiverse/web/bundler/qute/components/deployment/WebBundlerQuteComponentsProcessor.java
+++ b/integrations/qute-components/deployment/src/main/java/io/quarkiverse/web/bundler/qute/components/deployment/WebBundlerQuteComponentsProcessor.java
@@ -31,7 +31,7 @@ class WebBundlerQuteComponentsProcessor {
             throws IOException {
 
         LOGGER.debug("Web Bundler scan - Qute Web Components: start");
-        List<String> dirs = config.bundleWithDefault(true).entrySet().stream()
+        List<String> dirs = config.bundleWithDefault().entrySet().stream()
                 .filter(e -> e.getValue().quteTags())
                 .map(e -> config.prefixWithWebRoot(e.getValue().effectiveDir(e.getKey())))
                 .toList();


### PR DESCRIPTION
## Summary

- Remove the binary `checkAppDir()` toggle that forced scanning either `web/` OR `web/app/`, never both
- The default "app" entry point now scans both `web/app/` (primary) and loose root-level files from `web/` (supplementary)
- Root-level files are remapped to `web/app/` in the esbuild working directory so imports and overrides work correctly
- Root scanning only applies when no custom entry points are configured (preserving existing multi-entry-point behavior)

**Enables:** Libraries/themes can place assets in `web/app/` instead of `web/` root, freeing users to define custom entry points alongside theme assets. See #476.