### PR TITLE
Fix null pointer on runtime-processor scan

### DIFF
--- a/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/DevWatcherProcessor.java
+++ b/common/deployment/src/main/java/io/quarkiverse/web/bundler/deployment/DevWatcherProcessor.java
@@ -148,7 +148,7 @@ public class DevWatcherProcessor {
                     changes.stream().map(c -> c.getType() + " " + c.getFile()).toList());
 
             if (web) {
-                if (detectedAddOrRemoveChanges(changes)) {
+                if (detectedAddOrRemoveChanges(changes) && RuntimeUpdatesProcessor.INSTANCE != null) {
                     // This makes sure we build even if there was an error in a previous build
                     RuntimeUpdatesProcessor.INSTANCE.setRemoteProblem(null);
                     doScan(true);
@@ -186,8 +186,12 @@ public class DevWatcherProcessor {
 
         private void doScan(boolean forceRestart) {
             BUILD_EXECUTOR.executeIfNotRunning(() -> {
-                LOG.infof("Checking for Quarkus build (forceRestart: %s)", forceRestart);
-                RuntimeUpdatesProcessor.INSTANCE.doScan(false, forceRestart);
+                if (RuntimeUpdatesProcessor.INSTANCE != null) {
+                    LOG.infof("Checking for Quarkus build (forceRestart: %s)", forceRestart);
+                    RuntimeUpdatesProcessor.INSTANCE.doScan(false, forceRestart);
+                } else {
+                    LOG.warn("Runtime updates processor is null, not scanning!");
+                }
             });
         }
 


### PR DESCRIPTION
When running tests in the deployment module of my Quarkus extension, I ran into a `NPE` which is thrown due to the `RuntimeUpdatesProcessor.INSTANCE` being null.

It happens after the web-bundler dev services are stopping. The `DevWatcherProcessor` then tries to check for Quarkus build and accesses `RuntimeUpdatesProcessor.INSTANCE` without null-check.

I added said null-check as this, in general, seems unsafe to assume `RuntimeUpdatesProcessor.INSTANCE` not-null.

**To be clear here:** The NPE does not affect anything regarding test execution. It does not break behaviour, so rather a output-cosmetics issue.