### PR TITLE
Add separate RAG artifact for documentation search

### DIFF
--- a/core/deployment/src/main/resources/META-INF/quarkus-rag-artifact.properties
+++ b/core/deployment/src/main/resources/META-INF/quarkus-rag-artifact.properties
@@ -1,0 +1,2 @@
+groupId=io.quarkiverse.web-bundler
+artifactId=quarkus-web-bundler-rag

--- a/core/rag/pom.xml
+++ b/core/rag/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.web-bundler</groupId>
+        <artifactId>quarkus-web-bundler-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-web-bundler-rag</artifactId>
+    <name>Quarkus Web Bundler - RAG</name>
+    <description>RAG vector embeddings for Quarkus Web Bundler documentation</description>
+
+    <properties>
+        <skipRagGeneration>true</skipRagGeneration>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-extension-descriptor</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-documentation-rag-maven-plugin</artifactId>
+                <version>0.0.5</version>
+                <executions>
+                    <execution>
+                        <id>generate-rag</id>
+                        <goals>
+                            <goal>generate-rag</goal>
+                        </goals>
+                        <configuration>
+                            <guidesDirectory>${project.basedir}/../../docs/modules/ROOT/pages</guidesDirectory>
+                            <skip>${skipRagGeneration}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>rag</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>core/spi</module>
         <module>core/runtime</module>
         <module>core/deployment</module>
+        <module>core/rag</module>
         <module>integrations</module>
     </modules>
     <scm>


### PR DESCRIPTION
Ships RAG vector embeddings in a dedicated `core/rag` module so AI assistants (quarkus-agent-mcp, chappie) can search the extension's documentation. The deployment JAR includes a pointer file (`META-INF/quarkus-rag-artifact.properties`) that tells the loader where to find the RAG artifact.

- RAG module produces 50 chunks from 7 doc pages (116K JAR)
- Deployment JAR unchanged (only gains a 63-byte pointer file)
- RAG generation skipped by default, enabled with `-Prag` or `-Prelease`

Depends on quarkusio/quarkus-agent-mcp#215 and chappie-bot/chappie-server#43 for the loader-side pointer file support.