### PR TITLE
Fix DevMode tests for Quarkus snapshot basePath change

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/web/bundler/test/WebBundlerDevModeTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/web/bundler/test/WebBundlerDevModeTest.java
@@ -21,6 +21,8 @@ public class WebBundlerDevModeTest {
 
     @Test
     public void test() throws InterruptedException {
+        // Reset basePath since QuarkusDevModeTest may set it from quarkus.http.root-path
+        RestAssured.basePath = "";
         RestAssured.given()
                 .get("/foo/bar/")
                 .then()

--- a/core/deployment/src/test/java/io/quarkiverse/web/bundler/test/WebBundlerDevModeWatchTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/web/bundler/test/WebBundlerDevModeWatchTest.java
@@ -21,6 +21,8 @@ public class WebBundlerDevModeWatchTest {
 
     @Test
     public void test() throws InterruptedException {
+        // Reset basePath since QuarkusDevModeTest may set it from quarkus.http.root-path
+        RestAssured.basePath = "";
         RestAssured.given()
                 .get("/foo/bar/")
                 .then()


### PR DESCRIPTION
## Summary
- Reset `RestAssured.basePath` to `""` in DevMode tests that use a custom `quarkus.http.root-path`
- Quarkus PR quarkusio/quarkus#55016 now sets `RestAssured.basePath` from `quarkus.http.root-path` in `QuarkusDevModeTest`, which caused the root path to be doubled in our test requests