### PR TITLE
Fix addTrailingSlashIfNoExt checking entire path for dots

### DIFF
--- a/tools/string-paths/src/main/java/io/quarkiverse/tools/stringpaths/StringPaths.java
+++ b/tools/string-paths/src/main/java/io/quarkiverse/tools/stringpaths/StringPaths.java
@@ -64,7 +64,8 @@ public final class StringPaths {
      */
     public static String addTrailingSlashIfNoExt(String path) {
         Objects.requireNonNull(path, "path is required");
-        if (path.contains(".")) {
+        int lastSlash = path.lastIndexOf('/');
+        if (path.indexOf('.', lastSlash + 1) >= 0) {
             return path;
         }
         return path.endsWith("/") ? path : path + "/";

--- a/tools/string-paths/src/test/java/io/quarkiverse/tools/stringpaths/StringPathsTest.java
+++ b/tools/string-paths/src/test/java/io/quarkiverse/tools/stringpaths/StringPathsTest.java
@@ -52,6 +52,14 @@ class StringPathsTest {
         assertThat(StringPaths.addTrailingSlashIfNoExt("foo/")).isEqualTo("foo/");
         assertThat(StringPaths.addTrailingSlashIfNoExt("foo.html")).isEqualTo("foo.html");
         assertThat(StringPaths.addTrailingSlashIfNoExt("dir/foo.js")).isEqualTo("dir/foo.js");
+        // dot in directory component should not prevent trailing slash
+        assertThat(StringPaths.addTrailingSlashIfNoExt("dir.name/foo")).isEqualTo("dir.name/foo/");
+        assertThat(StringPaths.addTrailingSlashIfNoExt("v3.27/guide")).isEqualTo("v3.27/guide/");
+        assertThat(StringPaths.addTrailingSlashIfNoExt("a.b/c.d/bar")).isEqualTo("a.b/c.d/bar/");
+        // dot in directory but file has extension
+        assertThat(StringPaths.addTrailingSlashIfNoExt("v3.27/index.html")).isEqualTo("v3.27/index.html");
+        // already has trailing slash with dotted dir
+        assertThat(StringPaths.addTrailingSlashIfNoExt("dir.name/foo/")).isEqualTo("dir.name/foo/");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `addTrailingSlashIfNoExt()` was using `path.contains(".")` which matched dots in directory components (e.g. `v3.27/guide`), incorrectly treating them as file extensions
- Now checks only the filename portion (after the last `/`) for a dot, with no extra allocations

Fixes #473